### PR TITLE
Add a separate feature for each blosc filter. Conditionally compile for each blosc filter.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Document workspace
         env:
           RUSTDOCFLAGS: "--cfg docsrs"
-        run: cargo doc --features static,zlib,blosc,lzf,f16,complex
+        run: cargo doc --features static,zlib,blosc-all,lzf,f16,complex
 
   brew:
     name: brew
@@ -163,12 +163,12 @@ jobs:
       - name: Build and test all crates
         run: cargo test --workspace -vvv --features hdf5-sys/static,hdf5-sys/zlib --exclude hdf5-metno-derive
       - name: Build and test with filters and other features
-        run: cargo test --workspace -v --features hdf5-sys/static,hdf5-sys/zlib,lzf,blosc,f16,complex --exclude hdf5-metno-derive
+        run: cargo test --workspace -v --features hdf5-sys/static,hdf5-sys/zlib,lzf,blosc-all,f16,complex --exclude hdf5-metno-derive
         if: matrix.rust != 'stable-gnu'
       - name: Run examples
         run: |
-          cargo r --example simple --features hdf5-sys/static,hdf5-sys/zlib,lzf,blosc
-          cargo r --example chunking --features hdf5-sys/static,hdf5-sys/zlib,lzf,blosc
+          cargo r --example simple --features hdf5-sys/static,hdf5-sys/zlib,lzf,blosc-all
+          cargo r --example chunking --features hdf5-sys/static,hdf5-sys/zlib,lzf,blosc-all
         if: matrix.rust != 'stable-gnu'
 
   apt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 ## hdf5-src unreleased
 
 ## hdf5 unreleased
-Breaking:
-- Removed H5Type impl for tuples. It is recommended instead to use a struct and `derive` `H5Type` on this. See [`#54`](https://github.com/metno/hdf5-rust/issues/54) for an explanation of the issue with the old implementation.
+- Removed H5Type impl for tuples. It is recommended instead to use a struct and `derive` `H5Type` on this. See [`#54`](https://github.com/metno/hdf5-rust/issues/54) for an explanation of the issue with the old implementation (breaking change)
+- Added features for each blosc filter type. Without enabling the blosc filter one can not set the corresponding filter flag (breaking change)
 
 ## hdf5 v0.9.4
 Release date: Jan 13, 2025.

--- a/hdf5/Cargo.toml
+++ b/hdf5/Cargo.toml
@@ -23,6 +23,16 @@ zlib = ["hdf5-sys/zlib"]
 lzf = ["dep:lzf-sys", "dep:errno"]
 # Enable blosc compression filters.
 blosc = ["dep:blosc-sys"]
+# Enable blosc LZ4 compression filter.
+blosc-lz4 = ["blosc", "blosc-sys/lz4"]
+# Enable blosc zlib compression filter.
+blosc-zlib = ["blosc", "blosc-sys/zlib"]
+# Enable blosc zstd compression filter.
+blosc-zstd = ["blosc", "blosc-sys/zstd"]
+# Enable blosc snappy compression filter.
+blosc-snappy = ["blosc", "blosc-sys/snappy"]
+# Enable all blosc compression filters.
+blosc-all = ["blosc", "blosc-lz4", "blosc-zlib", "blosc-zstd", "blosc-snappy"]
 # Enable MPI support.
 mpio = ["dep:mpi-sys", "hdf5-sys/mpio"]
 # Enable complex number type support.

--- a/hdf5/examples/simple.rs
+++ b/hdf5/examples/simple.rs
@@ -33,7 +33,7 @@ fn write_hdf5() -> Result<()> {
     #[cfg(feature = "blosc")]
     blosc_set_nthreads(2); // set number of blosc threads
     let builder = group.new_dataset_builder();
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-zstd")]
     let builder = builder.blosc_zstd(9, true); // zstd + shuffle
     let ds = builder
         .with_data(&arr2(&[

--- a/hdf5/src/hl/dataset.rs
+++ b/hdf5/src/hl/dataset.rs
@@ -665,31 +665,31 @@ impl DatasetBuilderInner {
         self.with_dcpl(|pl| pl.blosc_blosclz(clevel, shuffle));
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-lz4")]
     pub fn blosc_lz4(&mut self, clevel: u8, shuffle: impl Into<BloscShuffle>) {
         let shuffle = shuffle.into();
         self.with_dcpl(|pl| pl.blosc_lz4(clevel, shuffle));
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-lz4")]
     pub fn blosc_lz4hc(&mut self, clevel: u8, shuffle: impl Into<BloscShuffle>) {
         let shuffle = shuffle.into();
         self.with_dcpl(|pl| pl.blosc_lz4hc(clevel, shuffle));
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-snappy")]
     pub fn blosc_snappy(&mut self, clevel: u8, shuffle: impl Into<BloscShuffle>) {
         let shuffle = shuffle.into();
         self.with_dcpl(|pl| pl.blosc_snappy(clevel, shuffle));
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-zlib")]
     pub fn blosc_zlib(&mut self, clevel: u8, shuffle: impl Into<BloscShuffle>) {
         let shuffle = shuffle.into();
         self.with_dcpl(|pl| pl.blosc_zlib(clevel, shuffle));
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-zstd")]
     pub fn blosc_zstd(&mut self, clevel: u8, shuffle: impl Into<BloscShuffle>) {
         let shuffle = shuffle.into();
         self.with_dcpl(|pl| pl.blosc_zstd(clevel, shuffle));
@@ -935,23 +935,23 @@ macro_rules! impl_builder_methods {
             DatasetCreate: blosc_blosclz(clevel: u8, shuffle: impl Into<BloscShuffle>)
         );
         impl_builder!(
-            #[cfg(feature = "blosc")]
+            #[cfg(feature = "blosc-lz4")]
             DatasetCreate: blosc_lz4(clevel: u8, shuffle: impl Into<BloscShuffle>)
         );
         impl_builder!(
-            #[cfg(feature = "blosc")]
+            #[cfg(feature = "blosc-lz4")]
             DatasetCreate: blosc_lz4hc(clevel: u8, shuffle: impl Into<BloscShuffle>)
         );
         impl_builder!(
-            #[cfg(feature = "blosc")]
+            #[cfg(feature = "blosc-snappy")]
             DatasetCreate: blosc_snappy(clevel: u8, shuffle: impl Into<BloscShuffle>)
         );
         impl_builder!(
-            #[cfg(feature = "blosc")]
+            #[cfg(feature = "blosc-zlib")]
             DatasetCreate: blosc_zlib(clevel: u8, shuffle: impl Into<BloscShuffle>)
         );
         impl_builder!(
-            #[cfg(feature = "blosc")]
+            #[cfg(feature = "blosc-zstd")]
             DatasetCreate: blosc_zstd(clevel: u8, shuffle: impl Into<BloscShuffle>)
         );
         impl_builder!(DatasetCreate: add_filter(id: H5Z_filter_t, cdata: &[c_uint]));
@@ -1034,7 +1034,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-zstd")]
     fn test_blosc() {
         check_filter(|d| d.blosc_zstd(9, true), Filter::Blosc(Blosc::ZStd, 9, BloscShuffle::Byte));
     }

--- a/hdf5/src/hl/filters.rs
+++ b/hdf5/src/hl/filters.rs
@@ -39,6 +39,7 @@ pub enum ScaleOffset {
 mod blosc_impl {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     #[cfg(feature = "blosc")]
+    #[non_exhaustive]
     pub enum Blosc {
         BloscLZ,
         #[cfg(feature = "blosc-lz4")]

--- a/hdf5/src/hl/filters.rs
+++ b/hdf5/src/hl/filters.rs
@@ -41,10 +41,15 @@ mod blosc_impl {
     #[cfg(feature = "blosc")]
     pub enum Blosc {
         BloscLZ,
+        #[cfg(feature = "blosc-lz4")]
         LZ4,
+        #[cfg(feature = "blosc-lz4")]
         LZ4HC,
+        #[cfg(feature = "blosc-snappy")]
         Snappy,
+        #[cfg(feature = "blosc-zlib")]
         ZLib,
+        #[cfg(feature = "blosc-zstd")]
         ZStd,
     }
 
@@ -245,7 +250,7 @@ impl Filter {
         Self::blosc(Blosc::BloscLZ, clevel, shuffle)
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-lz4")]
     pub fn blosc_lz4<T>(clevel: u8, shuffle: T) -> Self
     where
         T: Into<BloscShuffle>,
@@ -253,7 +258,7 @@ impl Filter {
         Self::blosc(Blosc::LZ4, clevel, shuffle)
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-lz4")]
     pub fn blosc_lz4hc<T>(clevel: u8, shuffle: T) -> Self
     where
         T: Into<BloscShuffle>,
@@ -261,7 +266,7 @@ impl Filter {
         Self::blosc(Blosc::LZ4HC, clevel, shuffle)
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-snappy")]
     pub fn blosc_snappy<T>(clevel: u8, shuffle: T) -> Self
     where
         T: Into<BloscShuffle>,
@@ -269,7 +274,7 @@ impl Filter {
         Self::blosc(Blosc::Snappy, clevel, shuffle)
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-zlib")]
     pub fn blosc_zlib<T>(clevel: u8, shuffle: T) -> Self
     where
         T: Into<BloscShuffle>,
@@ -277,7 +282,7 @@ impl Filter {
         Self::blosc(Blosc::ZLib, clevel, shuffle)
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-zstd")]
     pub fn blosc_zstd<T>(clevel: u8, shuffle: T) -> Self
     where
         T: Into<BloscShuffle>,
@@ -373,10 +378,15 @@ impl Filter {
         let complib = if cdata.len() >= 7 {
             match cdata[6] {
                 blosc::BLOSC_BLOSCLZ => Blosc::BloscLZ,
+                #[cfg(feature = "blosc-lz4")]
                 blosc::BLOSC_LZ4 => Blosc::LZ4,
+                #[cfg(feature = "blosc-lz4")]
                 blosc::BLOSC_LZ4HC => Blosc::LZ4HC,
+                #[cfg(feature = "blosc-snappy")]
                 blosc::BLOSC_SNAPPY => Blosc::Snappy,
+                #[cfg(feature = "blosc-zlib")]
                 blosc::BLOSC_ZLIB => Blosc::ZLib,
+                #[cfg(feature = "blosc-zstd")]
                 blosc::BLOSC_ZSTD => Blosc::ZStd,
                 _ => fail!("invalid blosc complib: {}", cdata[6]),
             }
@@ -453,10 +463,15 @@ impl Filter {
         };
         cdata[6] = match complib {
             Blosc::BloscLZ => blosc::BLOSC_BLOSCLZ,
+            #[cfg(feature = "blosc-lz4")]
             Blosc::LZ4 => blosc::BLOSC_LZ4,
+            #[cfg(feature = "blosc-lz4")]
             Blosc::LZ4HC => blosc::BLOSC_LZ4HC,
+            #[cfg(feature = "blosc-snappy")]
             Blosc::Snappy => blosc::BLOSC_SNAPPY,
+            #[cfg(feature = "blosc-zlib")]
             Blosc::ZLib => blosc::BLOSC_ZLIB,
+            #[cfg(feature = "blosc-zstd")]
             Blosc::ZStd => blosc::BLOSC_ZSTD,
         };
         Self::apply_user(plist_id, blosc::BLOSC_FILTER_ID, &cdata)
@@ -594,8 +609,8 @@ mod tests {
         {
             comp_filters.push(Filter::lzf());
         }
-        assert_eq!(cfg!(feature = "blosc"), blosc_available());
-        #[cfg(feature = "blosc")]
+        assert_eq!(cfg!(feature = "blosc-all"), blosc_available());
+        #[cfg(feature = "blosc-all")]
         {
             use super::BloscShuffle;
             comp_filters.push(Filter::blosc_blosclz(1, false));

--- a/hdf5/src/hl/filters/blosc.rs
+++ b/hdf5/src/hl/filters/blosc.rs
@@ -12,9 +12,20 @@ use crate::globals::{H5E_CALLBACK, H5E_PLIST};
 use crate::internal_prelude::*;
 
 pub use blosc_sys::{
-    BLOSC_BITSHUFFLE, BLOSC_BLOSCLZ, BLOSC_LZ4, BLOSC_LZ4HC, BLOSC_MAX_TYPESIZE, BLOSC_NOSHUFFLE,
-    BLOSC_SHUFFLE, BLOSC_SNAPPY, BLOSC_VERSION_FORMAT, BLOSC_ZLIB, BLOSC_ZSTD,
+    BLOSC_BITSHUFFLE, BLOSC_BLOSCLZ, BLOSC_MAX_TYPESIZE, BLOSC_NOSHUFFLE, BLOSC_SHUFFLE,
+    BLOSC_VERSION_FORMAT,
 };
+
+#[cfg(feature = "blosc-lz4")]
+pub use blosc_sys::BLOSC_LZ4;
+#[cfg(feature = "blosc-lz4")]
+pub use blosc_sys::BLOSC_LZ4HC;
+#[cfg(feature = "blosc-snappy")]
+pub use blosc_sys::BLOSC_SNAPPY;
+#[cfg(feature = "blosc-zlib")]
+pub use blosc_sys::BLOSC_ZLIB;
+#[cfg(feature = "blosc-zstd")]
+pub use blosc_sys::BLOSC_ZSTD;
 
 pub use blosc_sys::{
     blosc_cbuffer_sizes, blosc_compcode_to_compname, blosc_compress, blosc_decompress,

--- a/hdf5/src/hl/plist/dataset_create.rs
+++ b/hdf5/src/hl/plist/dataset_create.rs
@@ -430,7 +430,7 @@ impl DatasetCreateBuilder {
         self
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-lz4")]
     pub fn blosc_lz4<T>(&mut self, clevel: u8, shuffle: T) -> &mut Self
     where
         T: Into<BloscShuffle>,
@@ -439,7 +439,7 @@ impl DatasetCreateBuilder {
         self
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-lz4")]
     pub fn blosc_lz4hc<T>(&mut self, clevel: u8, shuffle: T) -> &mut Self
     where
         T: Into<BloscShuffle>,
@@ -448,7 +448,7 @@ impl DatasetCreateBuilder {
         self
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-snappy")]
     pub fn blosc_snappy<T>(&mut self, clevel: u8, shuffle: T) -> &mut Self
     where
         T: Into<BloscShuffle>,
@@ -457,7 +457,7 @@ impl DatasetCreateBuilder {
         self
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-zlib")]
     pub fn blosc_zlib<T>(&mut self, clevel: u8, shuffle: T) -> &mut Self
     where
         T: Into<BloscShuffle>,
@@ -466,7 +466,7 @@ impl DatasetCreateBuilder {
         self
     }
 
-    #[cfg(feature = "blosc")]
+    #[cfg(feature = "blosc-zstd")]
     pub fn blosc_zstd<T>(&mut self, clevel: u8, shuffle: T) -> &mut Self
     where
         T: Into<BloscShuffle>,


### PR DESCRIPTION
Fixes #52

Enable blosc filters from `blosc-sys` crate through features.

Adds the following features to `hdf5` crate.
- blosc-lz4
- blosc-zlib
- blosc-zstd
- blosc-snappy
- blosc-all

Additionally, blosc methods and enums for filters are conditionally compiled, so that only the methods and variants for each blosc filter are compiled for it's respective blosc feature.

This is a breaking change since methods and variants are removed based on features.