### PR TITLE
fix: Add Null Pointer Checks in String Type

### DIFF
--- a/hdf5-types/src/string.rs
+++ b/hdf5-types/src/string.rs
@@ -784,9 +784,7 @@ pub mod tests {
 
     #[test]
     fn test_null_pointer_var_len_ascii() {
-        let ascii = VarLenAscii {
-            ptr: ptr::null_mut()
-        };
+        let ascii = VarLenAscii { ptr: ptr::null_mut() };
 
         assert_eq!(ascii.len(), 0);
         let string = ascii.as_str();
@@ -796,9 +794,7 @@ pub mod tests {
 
     #[test]
     fn test_null_pointer_var_len_unicode() {
-        let unicode = VarLenUnicode {
-            ptr: ptr::null_mut()
-        };
+        let unicode = VarLenUnicode { ptr: ptr::null_mut() };
         assert_eq!(unicode.len(), 0);
         let string = unicode.as_str();
         assert_eq!(string, "");


### PR DESCRIPTION
Null pointers were not checked before libc length functions. This is now fixed and we return empty strings when the pointer is null.

Refs: https://github.com/metno/hdf5-rust/issues/69