### PR TITLE
add links to examples in the README + 1D chunked R/W example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,9 +167,12 @@ jobs:
         if: matrix.rust != 'stable-gnu'
       - name: Run examples
         run: |
-          cargo r --example simple --features hdf5-sys/static,hdf5-sys/zlib,lzf,blosc-all
-          cargo r --example chunking --features hdf5-sys/static,hdf5-sys/zlib,lzf,blosc-all
+          cargo r --example simple --features ${{ env.FEATURES }}
+          cargo r --example chunking --features ${{ env.FEATURES }}
+          cargo r --example continuously_rw_1d --features ${{ env.FEATURES }}
         if: matrix.rust != 'stable-gnu'
+        env:
+          FEATURES: hdf5-sys/static,hdf5-sys/zlib,lzf,blosc-all
 
   apt:
     name: apt

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ fn main() -> Result<()> {
 }
 ```
 
+You can find this [example][readme-example] as well as other example projects in
+the [example directory][examples].
+
 ## Compatibility
 
 ### Platforms
@@ -206,3 +209,7 @@ Few things to note when building on Windows:
 `hdf5` crate is primarily distributed under the terms of both the MIT license and the
 Apache License (Version 2.0). See [LICENSE-APACHE](LICENSE-APACHE) and
 [LICENSE-MIT](LICENSE-MIT) for details.
+
+
+[readme-example]: https://github.com/metno/hdf5-rust/blob/main/hdf5/examples/simple.rs
+[examples]: https://github.com/metno/hdf5-rust/tree/main/hdf5/examples

--- a/hdf5/examples/continuously_rw_1d.rs
+++ b/hdf5/examples/continuously_rw_1d.rs
@@ -27,7 +27,7 @@ fn write_hdf5() -> Result<()> {
     // Simulate continuously accumulating data in a buffer
     // and writing it to the dataset anytime there's enough to fill a chunk
     let mut buf = Vec::with_capacity(CHUNK_SIZE);
-    for i in 0..NUM_CHUNKS * 5 {
+    for i in 0..NUM_CHUNKS * CHUNK_SIZE {
         buf.push(i);
         if buf.len() == CHUNK_SIZE {
             let current_size = ds.size();
@@ -65,7 +65,7 @@ fn read_hdf5() -> Result<()> {
         let chunk_start = chunk_idx * chunk_size;
         let arr: Array1<usize> = ds.read_slice(chunk_start..chunk_start + chunk_size)?;
         println!("Dataset Chunk #{chunk_idx}: {arr:?}");
-        assert_eq!(arr, Array1::from_iter(chunk_idx * 5..chunk_idx * 5 + 5));
+        assert_eq!(arr, Array1::from_iter(chunk_start..chunk_start + chunk_size));
     }
 
     // Read the full dataset in one go

--- a/hdf5/examples/continuously_rw_1d.rs
+++ b/hdf5/examples/continuously_rw_1d.rs
@@ -16,13 +16,8 @@ const NUM_CHUNKS: usize = 3; // total chunks to write
 fn write_hdf5() -> Result<()> {
     println!("Creating file '{FILE_NAME}' with 1D resizable dataset");
     let file = File::create(FILE_NAME)?;
-    let shape = Extent::resizable(1); // 1D resizable
+    let shape = Extent::resizable(0); // 1D resizable
     let ds = file.new_dataset::<usize>().chunk((CHUNK_SIZE,)).shape(shape).create(DATASET_NAME)?;
-
-    // Dataset is created with length 1
-    // so we resize to 0 to only store "real" values
-    assert_eq!(ds.size(), 1);
-    ds.resize((0,))?;
 
     // Simulate continuously accumulating data in a buffer
     // and writing it to the dataset anytime there's enough to fill a chunk
@@ -49,7 +44,7 @@ fn read_hdf5() -> Result<()> {
     // Check shape
     let shape = ds.shape();
     println!("Dataset shape: {:?}", shape);
-    assert_eq!(shape, vec![CHUNK_SIZE * NUM_CHUNKS]);
+    assert_eq!(shape, &[CHUNK_SIZE * NUM_CHUNKS]);
 
     // Get chunking metadata
     let chunk_size = ds.chunk().unwrap()[0];

--- a/hdf5/examples/continuously_rw_1d.rs
+++ b/hdf5/examples/continuously_rw_1d.rs
@@ -1,0 +1,83 @@
+//! Create, and continuously write several chunks to a chunked 1D dataset
+//!
+//! Finally read it, get the chunking metadata, and use it to read slices aligned to the chunk size
+
+use hdf5::{File, Result};
+use hdf5_metno::{self as hdf5, Extent};
+use ndarray::Array1;
+
+// Shared between read_hdf5() and write_hdf5(), otherwise they only rely on file metadata
+const FILE_NAME: &str = "continuous_chunks.h5";
+const DATASET_NAME: &str = "count";
+
+const CHUNK_SIZE: usize = 5;
+const NUM_CHUNKS: usize = 3; // total chunks to write
+
+fn write_hdf5() -> Result<()> {
+    println!("Creating file '{FILE_NAME}' with 1D resizable dataset");
+    let file = File::create(FILE_NAME)?;
+    let shape = Extent::resizable(1); // 1D resizable
+    let ds = file.new_dataset::<usize>().chunk((CHUNK_SIZE,)).shape(shape).create(DATASET_NAME)?;
+
+    // Dataset is created with length 1
+    // so we resize to 0 to only store "real" values
+    assert_eq!(ds.size(), 1);
+    ds.resize((0,))?;
+
+    // Simulate continuously accumulating data in a buffer
+    // and writing it to the dataset anytime there's enough to fill a chunk
+    let mut buf = Vec::with_capacity(CHUNK_SIZE);
+    for i in 0..NUM_CHUNKS * 5 {
+        buf.push(i);
+        if buf.len() == CHUNK_SIZE {
+            let current_size = ds.size();
+            println!("[{i}] writing new chunk, current size = {current_size}");
+            ds.resize((current_size + CHUNK_SIZE,))?;
+            ds.write_slice(&buf, current_size..current_size + CHUNK_SIZE)?;
+            buf.clear();
+        }
+    }
+
+    Ok(())
+}
+
+fn read_hdf5() -> Result<()> {
+    println!("Reading file '{FILE_NAME}'");
+    let file = File::open(FILE_NAME)?;
+    let ds = file.dataset(DATASET_NAME)?;
+
+    // Check shape
+    let shape = ds.shape();
+    println!("Dataset shape: {:?}", shape);
+    assert_eq!(shape, vec![CHUNK_SIZE * NUM_CHUNKS]);
+
+    // Get chunking metadata
+    let chunk_size = ds.chunk().unwrap()[0];
+    println!("Chunk size: {chunk_size}");
+    assert_eq!(chunk_size, CHUNK_SIZE);
+
+    let num_chunks = ds.num_chunks().unwrap();
+    println!("Number of chunks: {num_chunks}");
+    assert_eq!(num_chunks, NUM_CHUNKS);
+
+    // Read the dataset chunk for chunk
+    for chunk_idx in 0..num_chunks {
+        let chunk_start = chunk_idx * chunk_size;
+        let arr: Array1<usize> = ds.read_slice(chunk_start..chunk_start + chunk_size)?;
+        println!("Dataset Chunk #{chunk_idx}: {arr:?}");
+        assert_eq!(arr, Array1::from_iter(chunk_idx * 5..chunk_idx * 5 + 5));
+    }
+
+    // Read the full dataset in one go
+    let arr: Array1<usize> = ds.read_1d()?;
+    println!("Full dataset: {arr:?}");
+    assert_eq!(arr, Array1::from_iter(0..CHUNK_SIZE * NUM_CHUNKS));
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    write_hdf5()?;
+    read_hdf5()?;
+    Ok(())
+}

--- a/hdf5/examples/continuously_rw_1d.rs
+++ b/hdf5/examples/continuously_rw_1d.rs
@@ -2,77 +2,89 @@
 //!
 //! Finally read it, get the chunking metadata, and use it to read slices aligned to the chunk size
 
-use hdf5::{File, Result};
-use hdf5_metno::{self as hdf5, Extent};
-use ndarray::Array1;
+#[cfg(feature = "1.10.5")]
+fn main() -> hdf5_metno::Result<()> {
+    example::write_hdf5()?;
+    example::read_hdf5()?;
+    Ok(())
+}
 
-// Shared between read_hdf5() and write_hdf5(), otherwise they only rely on file metadata
-const FILE_NAME: &str = "continuous_chunks.h5";
-const DATASET_NAME: &str = "count";
+#[cfg(not(feature = "1.10.5"))]
+fn main() {
+    println!(
+        "needs version 1.10.5 or later for querying the number of chunks with H5Dget_num_chunks"
+    );
+}
 
-const CHUNK_SIZE: usize = 5;
-const NUM_CHUNKS: usize = 3; // total chunks to write
+#[cfg(feature = "1.10.5")]
+mod example {
+    use hdf5::{File, Result};
+    use hdf5_metno::{self as hdf5, Extent};
+    use ndarray::Array1;
 
-fn write_hdf5() -> Result<()> {
-    println!("Creating file '{FILE_NAME}' with 1D resizable dataset");
-    let file = File::create(FILE_NAME)?;
-    let shape = Extent::resizable(0); // 1D resizable
-    let ds = file.new_dataset::<usize>().chunk((CHUNK_SIZE,)).shape(shape).create(DATASET_NAME)?;
+    // Shared between read_hdf5() and write_hdf5(), otherwise they only rely on file metadata
+    const FILE_NAME: &str = "continuous_chunks.h5";
+    const DATASET_NAME: &str = "count";
 
-    // Simulate continuously accumulating data in a buffer
-    // and writing it to the dataset anytime there's enough to fill a chunk
-    let mut buf = Vec::with_capacity(CHUNK_SIZE);
-    for i in 0..NUM_CHUNKS * CHUNK_SIZE {
-        buf.push(i);
-        if buf.len() == CHUNK_SIZE {
-            let current_size = ds.size();
-            println!("[{i}] writing new chunk, current size = {current_size}");
-            ds.resize((current_size + CHUNK_SIZE,))?;
-            ds.write_slice(&buf, current_size..current_size + CHUNK_SIZE)?;
-            buf.clear();
+    const CHUNK_SIZE: usize = 5;
+    const NUM_CHUNKS: usize = 3; // total chunks to write
+
+    pub fn write_hdf5() -> Result<()> {
+        println!("Creating file '{FILE_NAME}' with 1D resizable dataset");
+        let file = File::create(FILE_NAME)?;
+        let shape = Extent::resizable(0); // 1D resizable
+        let ds =
+            file.new_dataset::<usize>().chunk((CHUNK_SIZE,)).shape(shape).create(DATASET_NAME)?;
+
+        // Simulate continuously accumulating data in a buffer
+        // and writing it to the dataset anytime there's enough to fill a chunk
+        let mut buf = Vec::with_capacity(CHUNK_SIZE);
+        for i in 0..NUM_CHUNKS * CHUNK_SIZE {
+            buf.push(i);
+            if buf.len() == CHUNK_SIZE {
+                let current_size = ds.size();
+                println!("[{i}] writing new chunk, current size = {current_size}");
+                ds.resize((current_size + CHUNK_SIZE,))?;
+                ds.write_slice(&buf, current_size..current_size + CHUNK_SIZE)?;
+                buf.clear();
+            }
         }
+
+        Ok(())
     }
 
-    Ok(())
-}
+    pub fn read_hdf5() -> Result<()> {
+        println!("Reading file '{FILE_NAME}'");
+        let file = File::open(FILE_NAME)?;
+        let ds = file.dataset(DATASET_NAME)?;
 
-fn read_hdf5() -> Result<()> {
-    println!("Reading file '{FILE_NAME}'");
-    let file = File::open(FILE_NAME)?;
-    let ds = file.dataset(DATASET_NAME)?;
+        // Check shape
+        let shape = ds.shape();
+        println!("Dataset shape: {:?}", shape);
+        assert_eq!(shape, &[CHUNK_SIZE * NUM_CHUNKS]);
 
-    // Check shape
-    let shape = ds.shape();
-    println!("Dataset shape: {:?}", shape);
-    assert_eq!(shape, &[CHUNK_SIZE * NUM_CHUNKS]);
+        // Get chunking metadata
+        let chunk_size = ds.chunk().unwrap()[0];
+        println!("Chunk size: {chunk_size}");
+        assert_eq!(chunk_size, CHUNK_SIZE);
 
-    // Get chunking metadata
-    let chunk_size = ds.chunk().unwrap()[0];
-    println!("Chunk size: {chunk_size}");
-    assert_eq!(chunk_size, CHUNK_SIZE);
+        let num_chunks = ds.num_chunks().unwrap();
+        println!("Number of chunks: {num_chunks}");
+        assert_eq!(num_chunks, NUM_CHUNKS);
 
-    let num_chunks = ds.num_chunks().unwrap();
-    println!("Number of chunks: {num_chunks}");
-    assert_eq!(num_chunks, NUM_CHUNKS);
+        // Read the dataset chunk for chunk
+        for chunk_idx in 0..num_chunks {
+            let chunk_start = chunk_idx * chunk_size;
+            let arr: Array1<usize> = ds.read_slice(chunk_start..chunk_start + chunk_size)?;
+            println!("Dataset Chunk #{chunk_idx}: {arr:?}");
+            assert_eq!(arr, Array1::from_iter(chunk_start..chunk_start + chunk_size));
+        }
 
-    // Read the dataset chunk for chunk
-    for chunk_idx in 0..num_chunks {
-        let chunk_start = chunk_idx * chunk_size;
-        let arr: Array1<usize> = ds.read_slice(chunk_start..chunk_start + chunk_size)?;
-        println!("Dataset Chunk #{chunk_idx}: {arr:?}");
-        assert_eq!(arr, Array1::from_iter(chunk_start..chunk_start + chunk_size));
+        // Read the full dataset in one go
+        let arr: Array1<usize> = ds.read_1d()?;
+        println!("Full dataset: {arr:?}");
+        assert_eq!(arr, Array1::from_iter(0..CHUNK_SIZE * NUM_CHUNKS));
+
+        Ok(())
     }
-
-    // Read the full dataset in one go
-    let arr: Array1<usize> = ds.read_1d()?;
-    println!("Full dataset: {arr:?}");
-    assert_eq!(arr, Array1::from_iter(0..CHUNK_SIZE * NUM_CHUNKS));
-
-    Ok(())
-}
-
-fn main() -> Result<()> {
-    write_hdf5()?;
-    read_hdf5()?;
-    Ok(())
 }


### PR DESCRIPTION
- Adds links to the examples in the README.
- Adds a new example of creating and continuously adding data to a 1D chunked dataset, and afterwards reading it chunked by using the chunking metadata of the file

The existing examples don't print what's happening to stdout, so they are not interactive in anyway which would be helpful I think, so I did that with the new example.

Feel free to nitpick, especially if I've misused the API in anyway and there's a simpler/better way to use it.

### Motivation

I know from experience that people are confused about creating and writing the simplest 1D datasets, even with `h5py` I see 2D datasets that are actually only 1D, which adds unnecessary complexity.

If you write a 1D dataset vs. the same but accidentally 2D and load them into https://myhdf5.hdfgroup.org/ you'll be confused and it's a hassle to inspect it vs. a 1D dataset.

The same confusion manifests in many other cases.