### PR TITLE
Implement proper way of getting name of HDF5 attribute + fix 106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ## hdf5-sys unreleased
 ## hdf5-src unreleased
 
+- Fixed incorrect retrieved name of attributes
+
 ## hdf5 v0.10.2
 Release date: Oct 16, 2025
 - Upgraded upper bound of ndarray

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 ## hdf5-derive unreleased
 ## hdf5-sys unreleased
 ## hdf5-src unreleased
-- Fixed incorrect retrieved name of attributes
 
 ## hdf5 unreleased
+- Fixed incorrect retrieved name of attributes
 - Added support for Single Writer Multiple Readers (SWMR) (breaking change, OpenMode has extra variant)
 
 ## hdf5 v0.10.2

--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -5,7 +5,7 @@ description = "Native bindings to the HDF5 library."
 links = "hdf5"
 readme = "README.md"
 categories = ["development-tools::ffi", "filesystem", "science"]
-version = "0.10.1"  # !V
+version = "0.10.1"                                               # !V
 rust-version.workspace = true
 authors.workspace = true
 keywords.workspace = true
@@ -28,7 +28,7 @@ mpio = ["dep:mpi-sys"]
 hl = ["hdf5-src?/hl"]
 threadsafe = ["hdf5-src?/threadsafe"]
 zlib = ["dep:libz-sys", "hdf5-src?/zlib"]
-static = ["dep:hdf5-src"]
+static = ["hdf5-src/threadsafe"]
 deprecated = ["hdf5-src?/deprecated"]
 
 [build-dependencies]

--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -5,7 +5,7 @@ description = "Native bindings to the HDF5 library."
 links = "hdf5"
 readme = "README.md"
 categories = ["development-tools::ffi", "filesystem", "science"]
-version = "0.10.1"                                               # !V
+version = "0.10.1"  # !V
 rust-version.workspace = true
 authors.workspace = true
 keywords.workspace = true
@@ -28,7 +28,7 @@ mpio = ["dep:mpi-sys"]
 hl = ["hdf5-src?/hl"]
 threadsafe = ["hdf5-src?/threadsafe"]
 zlib = ["dep:libz-sys", "hdf5-src?/zlib"]
-static = ["hdf5-src/threadsafe"]
+static = ["dep:hdf5-src"]
 deprecated = ["hdf5-src?/deprecated"]
 
 [build-dependencies]

--- a/hdf5/src/hl/attribute.rs
+++ b/hdf5/src/hl/attribute.rs
@@ -271,13 +271,24 @@ impl AttributeBuilderInner {
 
         let dataspace = Dataspace::try_new(extents)?;
 
+        let acpl = PropertyList::from_id(h5call!(hdf5_sys::h5p::H5Pcreate(
+            *crate::globals::H5P_ATTRIBUTE_CREATE
+        ))?)?;
+        // Set UTF-8 encoding for the attribute name, as Rust strings are UTF-8.
+        h5call!(hdf5_sys::h5p::H5Pset_char_encoding(
+            acpl.id(),
+            hdf5_sys::h5t::H5T_cset_t::H5T_CSET_UTF8
+        ))?;
+
         let name = to_cstring(name)?;
         Attribute::from_id(h5try!(H5Acreate2(
             parent.id(),
             name.as_ptr(),
             datatype.id(),
             dataspace.id(),
-            H5P_DEFAULT,
+            acpl.id(),
+            // Unused as of v1.14
+            // see more: https://hdfgroup.github.io/hdf5/v1_14/group___h5_a.html#ga4f4e5248c09f689633079ed8afc0b308
             H5P_DEFAULT,
         )))
     }

--- a/hdf5/src/hl/attribute.rs
+++ b/hdf5/src/hl/attribute.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use std::ptr::addr_of_mut;
 
 use hdf5_sys::h5a::H5Aget_name;
+use hdf5_sys::h5p::H5Pcreate;
 use hdf5_sys::{
     h5::{H5_index_t, H5_iter_order_t},
     h5a::{H5A_info_t, H5A_operator2_t, H5Acreate2, H5Adelete, H5Aiterate2},
@@ -10,6 +11,7 @@ use hdf5_sys::{
 use hdf5_types::TypeDescriptor;
 use ndarray::ArrayView;
 
+use crate::globals::H5P_ATTRIBUTE_CREATE;
 use crate::internal_prelude::*;
 
 /// Represents the HDF5 attribute object.
@@ -271,9 +273,7 @@ impl AttributeBuilderInner {
 
         let dataspace = Dataspace::try_new(extents)?;
 
-        let acpl = PropertyList::from_id(h5call!(hdf5_sys::h5p::H5Pcreate(
-            *crate::globals::H5P_ATTRIBUTE_CREATE
-        ))?)?;
+        let acpl = PropertyList::from_id(h5call!(H5Pcreate(*H5P_ATTRIBUTE_CREATE))?)?;
         // Set UTF-8 encoding for the attribute name, as Rust strings are UTF-8.
         h5call!(hdf5_sys::h5p::H5Pset_char_encoding(
             acpl.id(),


### PR DESCRIPTION
Resolves https://github.com/metno/hdf5-rust/issues/106

And fix the the `name()` function returning the link name instead of the attribute name