### PR TITLE
ci: dont document dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Document workspace
         env:
           RUSTDOCFLAGS: "--cfg docsrs"
-        run: cargo doc --features static,zlib,blosc-all,lzf,f16,complex
+        run: cargo doc --features static,zlib,blosc-all,lzf,f16,complex --no-deps
 
   brew:
     name: brew


### PR DESCRIPTION
This is an attempt at fixing the docs-CI, which I saw is failing [here](https://github.com/metno/hdf5-rust/actions/runs/19497907947/job/55804580875?pr=79)

I dont think its necessary to build the docs of dependencies, at least in my projects I disabled it

Just a suggestion, up to you @mulimoen 