### PR TITLE
Static linking of MSVC runtime

### DIFF
--- a/hdf5-src/build.rs
+++ b/hdf5-src/build.rs
@@ -34,9 +34,7 @@ fn main() {
     let mut cfg = cmake::Config::new("ext/hdf5");
 
     if cfg!(target_env = "msvc") {
-        if let Ok(var) = env::var("CMAKE_POLICY_DEFAULT_CMP0091") {
-            cfg.define("CMAKE_POLICY_DEFAULT_CMP0091", var);
-        }
+        cfg.define("CMAKE_POLICY_DEFAULT_CMP0091", "NEW");
         if let Ok(var) = env::var("CMAKE_MSVC_RUNTIME_LIBRARY") {
             cfg.define("CMAKE_MSVC_RUNTIME_LIBRARY", var);
         }


### PR DESCRIPTION
Take into account env from .cargo/config.toml:
```
[target.x86_64-pc-windows-msvc]
rustflags = ["-C", "target-feature=+crt-static"]

[env]
# Make CMake-based dependencies use /MT
CMAKE_POLICY_DEFAULT_CMP0091 = { value = "NEW", force = true }
# Use static CRT in all configs; add Debug suffix automatically
CMAKE_MSVC_RUNTIME_LIBRARY = { value = "MultiThreaded$<$<CONFIG:Debug>:Debug>", force = true }
```
Fixes metno/hdf5-rust#112.