### PR TITLE
Fix build failure when enabling both `hl` & `threadsafe`

### DIFF
--- a/hdf5-src/build.rs
+++ b/hdf5-src/build.rs
@@ -61,7 +61,7 @@ fn main() {
     for option in &[
         "HDF5_ENABLE_DEPRECATED_SYMBOLS",
         "HDF5_ENABLE_THREADSAFE",
-        "ALLOW_UNSUPPORTED",
+        "HDF5_ALLOW_UNSUPPORTED",
         "HDF5_BUILD_HL_LIB",
         "HDF5_ENABLE_NONSTANDARD_FEATURE_FLOAT16",
         "HDF5_ENABLE_SZIP_SUPPORT",
@@ -91,7 +91,7 @@ fn main() {
         cfg.define("HDF5_ENABLE_THREADSAFE", "ON");
         if feature_enabled("HL") {
             println!("cargo::warning=Unsupported HDF5 options: hl with threadsafe.");
-            cfg.define("ALLOW_UNSUPPORTED", "ON");
+            cfg.define("HDF5_ALLOW_UNSUPPORTED", "ON");
         }
     }
 


### PR DESCRIPTION
The option `HDF5_ALLOW_UNSUPPORTED` was renamed to include the `HDF5_` prefix here:
https://github.com/HDFGroup/hdf5/commit/baa1e8e2922e520df740146141d24670db970a5e