### PR TITLE
feat: support pkg-config across all platforms

### DIFF
--- a/hdf5-sys/Cargo.toml
+++ b/hdf5-sys/Cargo.toml
@@ -34,8 +34,6 @@ deprecated = ["hdf5-src?/deprecated"]
 [build-dependencies]
 libloading = "0.8"
 regex = { workspace = true }
-
-[target.'cfg(any(all(unix, not(target_os = "macos")), windows))'.build-dependencies]
 pkg-config = "0.3"
 
 [target.'cfg(windows)'.build-dependencies]

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -251,7 +251,6 @@ pub struct LibrarySearcher {
     pub pkg_conf_found: bool,
 }
 
-#[cfg(any(all(unix, not(target_os = "macos")), windows))]
 mod pkgconf {
     use super::{is_inc_dir, LibrarySearcher};
 
@@ -303,7 +302,6 @@ mod pkgconf {
 
 #[cfg(all(unix, not(target_os = "macos")))]
 mod unix {
-    pub use super::pkgconf::find_hdf5_via_pkg_config;
     use super::{is_inc_dir, LibrarySearcher};
 
     pub fn find_hdf5_in_default_location(config: &mut LibrarySearcher) {
@@ -414,7 +412,6 @@ mod macos {
 
 #[cfg(windows)]
 mod windows {
-    pub use super::pkgconf::find_hdf5_via_pkg_config;
     use super::*;
 
     use std::io;
@@ -573,9 +570,9 @@ impl LibrarySearcher {
     }
 
     pub fn try_locate_hdf5_library(&mut self) {
+        self::pkgconf::find_hdf5_via_pkg_config(self);
         #[cfg(all(unix, not(target_os = "macos")))]
         {
-            self::unix::find_hdf5_via_pkg_config(self);
             self::unix::find_hdf5_in_default_location(self);
         }
         #[cfg(target_os = "macos")]
@@ -585,7 +582,6 @@ impl LibrarySearcher {
         #[cfg(windows)]
         {
             self::windows::find_hdf5_via_winreg(self);
-            self::windows::find_hdf5_via_pkg_config(self);
             // the check below is for dynamic linking only
             self::windows::validate_env_path(self);
         }


### PR DESCRIPTION
Some macOS users (e.g., those using nix-darwin) rely on pkg-config to locate HDF5, but the current build script only checks Homebrew. Additionally, on Windows, if both a registry-detected version and a pkg-config version are available, the script does not allow selecting the pkg-config version.

This PR introduces a new `pkg-config` feature flag to explicitly enable HDF5 detection via pkg-config. The library search logic is updated to try pkg-config first on all operating systems when this feature is enabled.

For backward compatibility, this feature is enabled by default.