### PR TITLE
bump regex and homebrew version detection to support hdf5_v2.1.*

### DIFF
--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -31,7 +31,7 @@ impl Version {
 
     pub fn parse(s: &str) -> Option<Self> {
         let re =
-            Regex::new(r"^(1|2)\.(0|8|10|12|14)\.(\d\d?)(_|.\d+)?((-|.)(patch)?\d+)?$").ok()?;
+            Regex::new(r"^(1|2)\.(0|8|10|12|14|1)\.(\d\d?)(_|.\d+)?((-|.)(patch)?\d+)?$").ok()?;
         let captures = re.captures(s)?;
         Some(Self {
             major: captures.get(1).and_then(|c| c.as_str().parse::<u8>().ok())?,
@@ -55,6 +55,7 @@ fn known_hdf5_versions() -> Vec<Version> {
     // Keep up to date with known_hdf5_versions in hdf5
     let mut vs = Vec::new();
     vs.push(Version::new(2, 0, 0)); // 2.0.0
+    vs.push(Version::new(2, 1, 0)); // 2.1.0
     vs.extend((5..=21).map(|v| Version::new(1, 8, v))); // 1.8.[5-23]
     vs.extend((0..=8).map(|v| Version::new(1, 10, v))); // 1.10.[0-10]
     vs.extend((0..=2).map(|v| Version::new(1, 12, v))); // 1.12.[0-2]
@@ -336,20 +337,23 @@ mod macos {
         }
         // We have to explicitly support homebrew since the HDF5 bottle isn't
         // packaged with pkg-config metadata.
-        let (v20, v18, v110, v112, v114) = if let Some(version) = config.version {
+        let (v20, v21, v18, v110, v112, v114) = if let Some(version) = config.version {
             (
                 version.major == 2 && version.minor == 0,
+                version.major == 2 && version.minor == 1,
                 version.major == 1 && version.minor == 8,
                 version.major == 1 && version.minor == 10,
                 version.major == 1 && version.minor == 12,
                 version.major == 1 && version.minor == 14,
             )
         } else {
-            (false, false, false, false, false)
+            (false, false, false, false, false, false)
         };
         println!(
             "Attempting to find HDF5 via Homebrew ({})...",
-            if v20 {
+            if v21 {
+                "2.1.*"
+            } else if v20 {
                 "2.0.*"
             } else if v18 {
                 "1.8.*"
@@ -364,6 +368,13 @@ mod macos {
             }
         );
         if !(v18 || v110 || v112 || v114) {
+            if let Some(out) = run_command("brew", &["--prefix", "hdf5@2.1"]) {
+                if is_root_dir(&out) {
+                    config.inc_dir = Some(PathBuf::from(out).join("include"));
+                }
+            }
+        }
+        if !(v18 || v110 || v112 || v114 || v21) {
             if let Some(out) = run_command("brew", &["--prefix", "hdf5@2.0"]) {
                 if is_root_dir(&out) {
                     config.inc_dir = Some(PathBuf::from(out).join("include"));


### PR DESCRIPTION
Not familiar with how your build system works but updated the macOS versioning to support 2.1.*. 
Ran cargo test successfully, hope that is everything you need from me!