### PR TITLE
chore: Replace proc-marcro-error2 with syn::Error.

### DIFF
--- a/hdf5-derive/Cargo.toml
+++ b/hdf5-derive/Cargo.toml
@@ -17,7 +17,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro-crate = "3.2.0"
-proc-macro-error2 = { version = "2.0", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["derive", "extra-traits"]}

--- a/hdf5-derive/src/lib.rs
+++ b/hdf5-derive/src/lib.rs
@@ -5,16 +5,14 @@ use std::mem;
 use std::str::FromStr;
 
 use proc_macro2::{Ident, Span, TokenStream};
-use proc_macro_error2::{abort, proc_macro_error};
 use quote::{quote, ToTokens};
 use syn::{
-    parse_macro_input, AttrStyle, Attribute, Data, DeriveInput, Expr, Fields, Index, LitStr, Type,
-    TypeGenerics, TypePath,
+    parse_macro_input, spanned::Spanned, AttrStyle, Attribute, Data, DeriveInput, Expr, Fields,
+    Index, LitStr, Type, TypeGenerics, TypePath,
 };
 
 /// Derive macro generating an impl of the trait `H5Type`.
 #[proc_macro_derive(H5Type, attributes(hdf5))]
-#[proc_macro_error]
 pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = input.ident;
@@ -141,7 +139,7 @@ fn find_repr(attrs: &[Attribute], expected: &[&str]) -> Option<Ident> {
         attr.parse_nested_meta(|meta| {
             if expected.iter().any(|s| meta.path.is_ident(s)) {
                 if repr.is_some() {
-                    abort!(meta.path, "ambiguous repr attribute");
+                    syn::Error::new(meta.path.span(), "ambiguous repr attribute");
                 } else {
                     repr = meta.path.get_ident().cloned();
                 }
@@ -180,21 +178,24 @@ fn impl_trait(
 ) -> TokenStream {
     match *data {
         Data::Struct(ref data) => match data.fields {
-            Fields::Unit => {
-                abort!(ty, "cannot derive `H5Type` for unit structs");
-            }
+            Fields::Unit => syn::Error::new(ty.span(), "cannot derive `H5Type` for unit structs")
+                .into_compile_error(),
             Fields::Named(ref fields) => {
                 let fields: Vec<_> =
                     fields.named.iter().filter(|f| !is_phantom_data(&f.ty)).collect();
                 if fields.is_empty() {
-                    abort!(ty, "cannot derive `H5Type` for empty structs");
+                    return syn::Error::new(ty.span(), "cannot derive `H5Type` for empty structs")
+                        .into_compile_error();
                 }
 
-                let repr =
-                    find_repr(attrs, &["C", "packed", "transparent"]).unwrap_or_else(|| {
-                        abort!(ty,
-                    "`H5Type` requires repr(C), repr(packed) or repr(transparent) for structs")
-                    });
+                let repr = match find_repr(attrs, &["C", "packed", "transparent"]) {
+                    Some(repr) => repr,
+                    None => return syn::Error::new(
+                        ty.span(),
+                        "`H5Type` requires repr(C), repr(packed) or repr(transparent) for structs",
+                    )
+                    .into_compile_error(),
+                };
                 if repr == "transparent" {
                     assert_eq!(fields.len(), 1);
                     impl_transparent(&fields[0].ty)
@@ -217,13 +218,20 @@ fn impl_trait(
                     .map(|(i, f)| (Index::from(i), f))
                     .unzip();
                 if fields.is_empty() {
-                    abort!(ty, "cannot derive `H5Type` for empty tuple structs")
+                    return syn::Error::new(
+                        ty.span(),
+                        "cannot derive `H5Type` for empty tuple structs",
+                    )
+                    .into_compile_error();
                 }
 
-                let repr =  find_repr(attrs, &["C", "packed", "transparent"]).unwrap_or_else(|| {
-                        abort!(ty,
-                    "`H5Type` requires repr(C), repr(packed) or repr(transparent) for tuple structs")
-                    });
+                let repr =  match find_repr(attrs, &["C", "packed", "transparent"]) {
+                    Some(repr) => repr,
+                    None => {
+                        return syn::Error::new(ty.span(),
+                    "`H5Type` requires repr(C), repr(packed) or repr(transparent) for tuple structs").into_compile_error()
+                    }
+                };
                 if repr == "transparent" {
                     assert_eq!(fields.len(), 1);
                     impl_transparent(&fields[0].ty)
@@ -242,18 +250,30 @@ fn impl_trait(
             let variants = &data.variants;
 
             if variants.iter().any(|v| v.fields != Fields::Unit || v.discriminant.is_none()) {
-                abort!(ty, "`H5Type` can only be derived for enums with scalar discriminants")
+                return syn::Error::new(
+                    ty.span(),
+                    "`H5Type` can only be derived for enums with scalar discriminants",
+                )
+                .to_compile_error();
             }
 
             if variants.is_empty() {
-                abort!(ty, "cannot derive `H5Type` for empty enums")
+                return syn::Error::new(ty.span(), "cannot derive `H5Type` for empty enums")
+                    .to_compile_error();
             }
 
             let enum_reprs =
                 &["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "isize", "usize"];
-            let repr = find_repr(attrs, enum_reprs).unwrap_or_else(|| {
-                abort!(ty, "`H5Type` can only be derived for enums with explicit representation")
-            });
+            let repr = match find_repr(attrs, enum_reprs) {
+                Some(repr) => repr,
+                None => {
+                    return syn::Error::new(
+                        ty.span(),
+                        "`H5Type` can only be derived for enums with explicit representation",
+                    )
+                    .into_compile_error();
+                }
+            };
             let names = variants
                 .iter()
                 .map(|v| find_hdf5_rename(&v.attrs).unwrap_or_else(|| v.ident.to_string()))
@@ -261,8 +281,7 @@ fn impl_trait(
             let values = pluck(variants.iter(), |v| v.discriminant.clone().unwrap().1);
             impl_enum(&names, &values, &repr)
         }
-        Data::Union(_) => {
-            abort!(ty, "cannot derive `H5Type` for tagged unions");
-        }
+        Data::Union(_) => syn::Error::new(ty.span(), "cannot derive `H5Type` for tagged unions")
+            .to_compile_error(),
     }
 }

--- a/hdf5-derive/tests/compile-fail/pd-empty-struct.rs
+++ b/hdf5-derive/tests/compile-fail/pd-empty-struct.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 #[derive(H5Type)]
 //~^ ERROR proc-macro derive
 //~^^ HELP Cannot derive H5Type for empty structs
-struct Foo<T> {
+struct Foo<T: 'static> {
     t: PhantomData<T>,
 }
 

--- a/hdf5-derive/tests/compile-fail/pd-empty-struct.stderr
+++ b/hdf5-derive/tests/compile-fail/pd-empty-struct.stderr
@@ -1,5 +1,5 @@
 error: cannot derive `H5Type` for empty structs
  --> tests/compile-fail/pd-empty-struct.rs:8:8
   |
-8 | struct Foo<T> {
+8 | struct Foo<T: 'static> {
   |        ^^^

--- a/hdf5-derive/tests/compile-fail/pd-empty-tuple-struct.rs
+++ b/hdf5-derive/tests/compile-fail/pd-empty-tuple-struct.rs
@@ -5,6 +5,6 @@ use std::marker::PhantomData;
 #[derive(H5Type)]
 //~^ ERROR proc-macro derive
 //~^^ HELP Cannot derive H5Type for empty tuple structs
-struct Foo<T>(PhantomData<T>);
+struct Foo<T: 'static>(PhantomData<T>);
 
 fn main() {}

--- a/hdf5-derive/tests/compile-fail/pd-empty-tuple-struct.stderr
+++ b/hdf5-derive/tests/compile-fail/pd-empty-tuple-struct.stderr
@@ -1,5 +1,5 @@
 error: cannot derive `H5Type` for empty tuple structs
  --> tests/compile-fail/pd-empty-tuple-struct.rs:8:8
   |
-8 | struct Foo<T>(PhantomData<T>);
+8 | struct Foo<T: 'static>(PhantomData<T>);
   |        ^^^


### PR DESCRIPTION
The proc-macro-error2 crate is unmaintained. Rather than migrate to another crate or fork this removes the use of the abort! macro in favour of using syn::Error. This allows the proc-macro-error2 dependency to be dropped, relying instead on syn for the error handling directly.

This implementation fails two tests because the error output from the updated implementation is more verbose than the previous implementation.