### PR TITLE
Reject incompatible enum conversions (issue 131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
-## hdf5 unreleased
 ## hdf5-derive unreleased
 ## hdf5-types unreleased
 ## hdf5-sys unreleased
 ## hdf5-src unreleased
+
+
+## hdf5 unreleased
+- Restrict enum conversions (breaking change, it is now an error reading incompatible enums)
 
 ## hdf5 0.12.6
 Release date: Jun 25, 2026

--- a/hdf5/src/hl/datatype.rs
+++ b/hdf5/src/hl/datatype.rs
@@ -6,9 +6,9 @@ use std::ptr::{addr_of, addr_of_mut};
 
 use hdf5_sys::h5t::{
     H5T_VARIABLE, H5T_cdata_t, H5T_class_t, H5T_cset_t, H5T_order_t, H5T_sign_t, H5T_str_t,
-    H5Tarray_create2, H5Tcompiler_conv, H5Tcopy, H5Tcreate, H5Tenum_create, H5Tenum_insert,
-    H5Tequal, H5Tfind, H5Tget_array_dims2, H5Tget_array_ndims, H5Tget_class, H5Tget_cset,
-    H5Tget_member_name, H5Tget_member_offset, H5Tget_member_type, H5Tget_member_value,
+    H5Tarray_create2, H5Tcompiler_conv, H5Tcopy, H5Tcreate, H5Tdetect_class, H5Tenum_create,
+    H5Tenum_insert, H5Tequal, H5Tfind, H5Tget_array_dims2, H5Tget_array_ndims, H5Tget_class,
+    H5Tget_cset, H5Tget_member_name, H5Tget_member_offset, H5Tget_member_type, H5Tget_member_value,
     H5Tget_nmembers, H5Tget_order, H5Tget_sign, H5Tget_size, H5Tget_super, H5Tinsert,
     H5Tis_variable_str, H5Tset_cset, H5Tset_size, H5Tset_strpad, H5Tvlen_create,
 };
@@ -282,15 +282,22 @@ impl Datatype {
                 conv <= required,
                 "Cannot convert from {self} to {dst}, required conversion {required}; available: {conv}",
             );
-            Self::ensure_enum_members_convertible(
-                &self.to_descriptor()?,
-                &dst.to_descriptor()?,
-                "datatype",
-            )?;
+            if self.contains_enum()? || dst.contains_enum()? {
+                Self::ensure_enum_members_convertible(
+                    &self.to_descriptor()?,
+                    &dst.to_descriptor()?,
+                    "datatype",
+                )?;
+            }
             Ok(())
         } else {
             fail!("no conversion paths found from '{self:#?}' to '{dst:#?}'",)
         }
+    }
+
+    /// Uses HDF5 class detection to avoid descriptor conversion for non-enum datatypes.
+    fn contains_enum(&self) -> Result<bool> {
+        Ok(h5call!(H5Tdetect_class(self.id(), H5T_class_t::H5T_ENUM))? > 0)
     }
 
     /// Compares enum leaves directly, otherwise follows matching nested descriptors.
@@ -437,6 +444,19 @@ impl Datatype {
                 H5T_class_t::H5T_VLEN => {
                     let base_dt = Self::from_id(H5Tget_super(id))?;
                     Ok(TD::VarLenArray(Box::new(base_dt.to_descriptor()?)))
+                }
+                H5T_class_t::H5T_REFERENCE => {
+                    #[cfg(feature = "1.12.0")]
+                    if h5try!(H5Tequal(id, *crate::globals::H5T_STD_REF)) > 0 {
+                        return Ok(TD::Reference(hdf5_types::Reference::Std));
+                    }
+                    if h5try!(H5Tequal(id, *crate::globals::H5T_STD_REF_OBJ)) > 0 {
+                        Ok(TD::Reference(hdf5_types::Reference::Object))
+                    } else if h5try!(H5Tequal(id, *crate::globals::H5T_STD_REF_DSETREG)) > 0 {
+                        Ok(TD::Reference(hdf5_types::Reference::Region))
+                    } else {
+                        Err("Unsupported reference datatype".into())
+                    }
                 }
                 _ => Err("Unsupported datatype class".into()),
             }

--- a/hdf5/src/hl/datatype.rs
+++ b/hdf5/src/hl/datatype.rs
@@ -19,6 +19,50 @@ use hdf5_types::{
 use crate::globals::{H5T_C_S1, H5T_NATIVE_INT, H5T_NATIVE_INT8};
 use crate::internal_prelude::*;
 
+enum EnumMembers<'a> {
+    Bool,
+    Enum(&'a [EnumMember]),
+}
+
+const BOOL_MEMBER_NAMES: &[&str] = &["FALSE", "TRUE"];
+
+impl EnumMembers<'_> {
+    /// Checks the fixed bool names or scans the enum member slice.
+    fn contains_name(&self, name: &str) -> bool {
+        match self {
+            Self::Bool => BOOL_MEMBER_NAMES.contains(&name),
+            Self::Enum(members) => members.iter().any(|member| member.name == name),
+        }
+    }
+
+    /// Collects source names that the destination member set cannot resolve.
+    fn missing_from(&self, dst: &Self) -> Vec<String> {
+        match self {
+            Self::Bool => BOOL_MEMBER_NAMES
+                .iter()
+                .filter(|name| !dst.contains_name(name))
+                .map(|name| name.to_string())
+                .collect(),
+            Self::Enum(members) => members
+                .iter()
+                .filter(|member| !dst.contains_name(&member.name))
+                .map(|member| member.name.to_owned())
+                .collect(),
+        }
+    }
+}
+
+impl<'a> EnumMembers<'a> {
+    /// Borrows enum members from descriptors, bool uses its normalized HDF5 enum names.
+    fn from_descriptor(desc: &'a TypeDescriptor) -> Option<Self> {
+        match desc {
+            TypeDescriptor::Boolean => Some(Self::Bool),
+            TypeDescriptor::Enum(enum_type) => Some(Self::Enum(&enum_type.members)),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(target_endian = "big")]
 use crate::globals::{
     H5T_IEEE_F32BE, H5T_IEEE_F64BE, H5T_STD_I8BE, H5T_STD_I16BE, H5T_STD_I32BE, H5T_STD_I64BE,
@@ -238,10 +282,71 @@ impl Datatype {
                 conv <= required,
                 "Cannot convert from {self} to {dst}, required conversion {required}; available: {conv}",
             );
+            Self::ensure_enum_members_convertible(
+                &self.to_descriptor()?,
+                &dst.to_descriptor()?,
+                "datatype",
+            )?;
             Ok(())
         } else {
             fail!("no conversion paths found from '{self:#?}' to '{dst:#?}'",)
         }
+    }
+
+    /// Compares enum leaves directly, otherwise follows matching nested descriptors.
+    fn ensure_enum_members_convertible(
+        src: &TypeDescriptor, dst: &TypeDescriptor, path: &str,
+    ) -> Result<()> {
+        if let Some((src_members, dst_members)) = Self::enum_member_sets(src, dst) {
+            Self::ensure_enum_member_names_present(&src_members, &dst_members, path)
+        } else {
+            Self::ensure_nested_enum_members_convertible(src, dst, path)
+        }
+    }
+
+    /// Treats bool as the HDF5 FALSE/TRUE enum when both descriptors are enum-like.
+    fn enum_member_sets<'a>(
+        src: &'a TypeDescriptor, dst: &'a TypeDescriptor,
+    ) -> Option<(EnumMembers<'a>, EnumMembers<'a>)> {
+        Some((EnumMembers::from_descriptor(src)?, EnumMembers::from_descriptor(dst)?))
+    }
+
+    /// Fails when a source enum name is absent from the destination enum.
+    fn ensure_enum_member_names_present(
+        src_members: &EnumMembers<'_>, dst_members: &EnumMembers<'_>, path: &str,
+    ) -> Result<()> {
+        let missing = src_members.missing_from(dst_members);
+        ensure!(
+            missing.is_empty(),
+            "Cannot convert enum at {path}: destination is missing source member{pluralize}: {}",
+            missing.join(", "),
+            pluralize = if missing.len() == 1 { "" } else { "s" }
+        );
+        Ok(())
+    }
+
+    /// Descends through matching compound fields and array element descriptors.
+    fn ensure_nested_enum_members_convertible(
+        src: &TypeDescriptor, dst: &TypeDescriptor, path: &str,
+    ) -> Result<()> {
+        match (src, dst) {
+            (TypeDescriptor::Compound(src_type), TypeDescriptor::Compound(dst_type)) => {
+                for &CompoundField { ref name, ref ty, offset: _, index: _ } in &src_type.fields {
+                    if let Some(dst_field) =
+                        dst_type.fields.iter().find(|dst_field| dst_field.name == *name)
+                    {
+                        let field_path = format!("{path}.{name}");
+                        Self::ensure_enum_members_convertible(&ty, &dst_field.ty, &field_path)?;
+                    }
+                }
+            }
+            (TypeDescriptor::FixedArray(src_type, _), TypeDescriptor::FixedArray(dst_type, _))
+            | (TypeDescriptor::VarLenArray(src_type), TypeDescriptor::VarLenArray(dst_type)) => {
+                Self::ensure_enum_members_convertible(src_type, dst_type, path)?;
+            }
+            _ => {}
+        }
+        Ok(())
     }
 
     /// Returns a type descriptor for the datatype.

--- a/hdf5/tests/test_dataset.rs
+++ b/hdf5/tests/test_dataset.rs
@@ -352,22 +352,6 @@ enum ExtendedEnum {
 }
 
 #[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
-#[repr(u8)]
-enum StoredNumberedEnum {
-    A = 0,
-    B = 1,
-    C = 2,
-}
-
-#[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
-#[repr(u8)]
-enum MemoryNumberedEnum {
-    A = 2,
-    B = 1,
-    C = 0,
-}
-
-#[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
 #[repr(C)]
 struct ShortEnumRecord {
     value: ShortEnum,
@@ -416,6 +400,22 @@ fn test_read_enum_converts_by_member_name() -> hdf5::Result<()> {
     // HDF5 enum types are symbol/value pairs, and enum conversion has a "No field" case:
     // https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t__u_g.html#subsubsec_datatype_other_enum
     // https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t__u_g.html#subsec_datatype_transfer
+    #[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
+    #[repr(u8)]
+    enum StoredNumberedEnum {
+        A = 0,
+        B = 1,
+        C = 2,
+    }
+
+    #[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
+    #[repr(u8)]
+    enum MemoryNumberedEnum {
+        A = 2,
+        B = 1,
+        C = 0,
+    }
+
     let file = new_in_memory_file()?;
     let data = [StoredNumberedEnum::A, StoredNumberedEnum::B, StoredNumberedEnum::C];
     let ds = file.new_dataset::<StoredNumberedEnum>().shape(data.len()).create("numbered")?;
@@ -471,6 +471,22 @@ fn test_read_compound_enum_rejects_missing_destination_variants() -> hdf5::Resul
         ),
         Err(_) => Ok(()),
     }
+}
+
+#[test]
+fn test_read_compound_enum_accepts_superset() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let data = [
+        ShortEnumRecord { value: ShortEnum::A },
+        ShortEnumRecord { value: ShortEnum::B },
+        ShortEnumRecord { value: ShortEnum::C },
+        ShortEnumRecord { value: ShortEnum::A },
+        ShortEnumRecord { value: ShortEnum::B },
+    ];
+    let ds = file.new_dataset::<ShortEnumRecord>().shape(data.len()).create("extended")?;
+    ds.write(&data)?;
+
+    ds.read_1d::<ExtendedEnumRecord>().map(|_| ())
 }
 
 #[test]

--- a/hdf5/tests/test_dataset.rs
+++ b/hdf5/tests/test_dataset.rs
@@ -332,6 +332,147 @@ fn test_read_write_enum() -> hdf5::Result<()> {
     test_read_write::<Enum>()
 }
 
+#[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
+#[allow(dead_code)]
+enum ShortEnum {
+    A = 0,
+    B = 1,
+    C = 2,
+}
+
+#[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
+enum ExtendedEnum {
+    A = 0,
+    B = 1,
+    C = 2,
+    D = 3,
+    E = 4,
+}
+
+#[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
+enum StoredNumberedEnum {
+    A = 0,
+    B = 1,
+    C = 2,
+}
+
+#[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
+enum MemoryNumberedEnum {
+    A = 2,
+    B = 1,
+    C = 0,
+}
+
+#[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+struct ShortEnumRecord {
+    value: ShortEnum,
+}
+
+#[derive(hdf5::H5Type, Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+struct ExtendedEnumRecord {
+    value: ExtendedEnum,
+}
+
+#[test]
+fn test_read_enum_rejects_missing_destination_variants() -> hdf5::Result<()> {
+    // Regression test for https://github.com/metno/hdf5-rust/issues/131
+    let file = new_in_memory_file()?;
+    let data =
+        [ExtendedEnum::A, ExtendedEnum::B, ExtendedEnum::C, ExtendedEnum::D, ExtendedEnum::E];
+    let ds = file.new_dataset::<ExtendedEnum>().shape(data.len()).create("extended")?;
+    ds.write(&data)?;
+    let actual = ds.read_1d::<ExtendedEnum>()?;
+
+    match ds.read_1d::<ShortEnum>() {
+        Ok(values) => panic!(
+            "reading enum values not representable by the requested type unexpectedly succeeded\nread as short enum: {:?}\nactual extended enum values: {:?}",
+            values.as_slice().unwrap(),
+            actual.as_slice().unwrap(),
+        ),
+        Err(_) => Ok(()),
+    }
+}
+
+#[test]
+fn test_read_enum_allows_destination_superset() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let data = [ShortEnum::A, ShortEnum::B, ShortEnum::C];
+    let ds = file.new_dataset::<ShortEnum>().shape(data.len()).create("short")?;
+    ds.write(&data)?;
+
+    let values = ds.read_1d::<ExtendedEnum>()?;
+    assert_eq!(values.as_slice().unwrap(), &[ExtendedEnum::A, ExtendedEnum::B, ExtendedEnum::C],);
+    Ok(())
+}
+
+#[test]
+fn test_read_enum_converts_by_member_name() -> hdf5::Result<()> {
+    // HDF5 enum types are symbol/value pairs, and enum conversion has a "No field" case:
+    // https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t__u_g.html#subsubsec_datatype_other_enum
+    // https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t__u_g.html#subsec_datatype_transfer
+    let file = new_in_memory_file()?;
+    let data = [StoredNumberedEnum::A, StoredNumberedEnum::B, StoredNumberedEnum::C];
+    let ds = file.new_dataset::<StoredNumberedEnum>().shape(data.len()).create("numbered")?;
+    ds.write(&data)?;
+
+    let values = ds.read_1d::<MemoryNumberedEnum>()?;
+    assert_eq!(
+        values.as_slice().unwrap(),
+        &[MemoryNumberedEnum::A, MemoryNumberedEnum::B, MemoryNumberedEnum::C],
+    );
+    Ok(())
+}
+
+#[test]
+fn test_write_enum_rejects_missing_dataset_variants() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let data =
+        [ExtendedEnum::A, ExtendedEnum::B, ExtendedEnum::C, ExtendedEnum::D, ExtendedEnum::E];
+    let ds = file.new_dataset::<ShortEnum>().shape(data.len()).create("short")?;
+
+    match ds.write(&data) {
+        Ok(()) => {
+            let stored = ds.read_1d::<ShortEnum>()?;
+            panic!(
+                "writing enum values not representable by the dataset type unexpectedly succeeded\nwritten as extended enum: {:?}\nstored as short enum: {:?}",
+                data,
+                stored.as_slice().unwrap(),
+            );
+        }
+        Err(_) => Ok(()),
+    }
+}
+
+#[test]
+fn test_read_compound_enum_rejects_missing_destination_variants() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let data = [
+        ExtendedEnumRecord { value: ExtendedEnum::A },
+        ExtendedEnumRecord { value: ExtendedEnum::B },
+        ExtendedEnumRecord { value: ExtendedEnum::C },
+        ExtendedEnumRecord { value: ExtendedEnum::D },
+        ExtendedEnumRecord { value: ExtendedEnum::E },
+    ];
+    let ds = file.new_dataset::<ExtendedEnumRecord>().shape(data.len()).create("extended")?;
+    ds.write(&data)?;
+    let actual = ds.read_1d::<ExtendedEnumRecord>()?;
+
+    match ds.read_1d::<ShortEnumRecord>() {
+        Ok(values) => panic!(
+            "reading compound enum values not representable by the requested type unexpectedly succeeded\nread as short record: {:?}\nactual extended record values: {:?}",
+            values.as_slice().unwrap(),
+            actual.as_slice().unwrap(),
+        ),
+        Err(_) => Ok(()),
+    }
+}
+
 #[test]
 fn test_read_write_tuple_struct() -> hdf5::Result<()> {
     test_read_write::<TupleStruct>()

--- a/hdf5/tests/test_dataset.rs
+++ b/hdf5/tests/test_dataset.rs
@@ -474,6 +474,25 @@ fn test_read_compound_enum_rejects_missing_destination_variants() -> hdf5::Resul
 }
 
 #[test]
+fn test_read_attribute_enum_rejects_missing_destination_variants() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let data =
+        [ExtendedEnum::A, ExtendedEnum::B, ExtendedEnum::C, ExtendedEnum::D, ExtendedEnum::E];
+    let attr = file.new_attr::<ExtendedEnum>().shape(data.len()).create("extended")?;
+    attr.write(&data)?;
+    let actual = attr.read_1d::<ExtendedEnum>()?;
+
+    match attr.read_1d::<ShortEnum>() {
+        Ok(values) => panic!(
+            "reading attribute enum values not representable by the requested type unexpectedly succeeded\nread as short enum: {:?}\nactual extended enum values: {:?}",
+            values.as_slice().unwrap(),
+            actual.as_slice().unwrap(),
+        ),
+        Err(_) => Ok(()),
+    }
+}
+
+#[test]
 fn test_read_write_tuple_struct() -> hdf5::Result<()> {
     test_read_write::<TupleStruct>()
 }

--- a/hdf5/tests/test_object_references.rs
+++ b/hdf5/tests/test_object_references.rs
@@ -153,6 +153,60 @@ fn test_reference_in_datatype<R: ObjectReference>() {
     }
 }
 
+fn test_reference_in_enum_datatype<R: ObjectReference>() {
+    let dummy_data = [1, 2, 3, 4];
+    let file = new_in_memory_file().unwrap();
+    let _ds1 = file.new_dataset_builder().with_data(&dummy_data).create("ds1").unwrap();
+    let ref1 = file.reference::<R>("ds1").unwrap();
+    let _ds2 = file.new_dataset_builder().with_data(&dummy_data).create("ds2").unwrap();
+    let ref2 = file.reference::<R>("ds2").unwrap();
+
+    #[derive(H5Type, Debug, PartialEq)]
+    #[repr(u8)]
+    enum State {
+        First = 0,
+        Second = 1,
+    }
+
+    #[derive(H5Type)]
+    #[repr(C)]
+    struct RefData<R: ObjectReference> {
+        dataset: R,
+        state: State,
+    }
+
+    let ds3 = file
+        .new_dataset_builder()
+        .with_data(&[
+            RefData { dataset: ref1, state: State::First },
+            RefData { dataset: ref2, state: State::Second },
+        ])
+        .create("ds3")
+        .unwrap();
+
+    let read_data = ds3.read_1d::<RefData<R>>().unwrap();
+    assert_eq!(read_data[0].state, State::First);
+    assert_eq!(read_data[1].state, State::Second);
+    match file.dereference(&read_data[0].dataset).unwrap() {
+        ReferencedObject::Dataset(ds) => {
+            assert_eq!(ds.name(), "/ds1");
+            assert_eq!(ds.read_1d::<i32>().unwrap().as_slice().unwrap(), &dummy_data);
+        }
+        _ => {
+            panic!("Expected a dataset reference");
+        }
+    }
+    match file.dereference(&read_data[1].dataset).unwrap() {
+        ReferencedObject::Dataset(ds) => {
+            assert_eq!(ds.name(), "/ds2");
+            assert_eq!(ds.read_1d::<i32>().unwrap().as_slice().unwrap(), &dummy_data);
+        }
+        _ => {
+            panic!("Expected a dataset reference");
+        }
+    }
+}
+
 /* TODO: Should this be possible? Reference not implementing Copy blocks this in a few places.
 #[test]
 fn test_references_in_array_types() {
@@ -218,6 +272,12 @@ fn test_reference_in_datatype_object_reference1() {
     test_reference_in_datatype::<ObjectReference1>();
 }
 
+// Compound datatypes can mix reference and enum fields without enum checks inspecting references.
+#[test]
+fn test_reference_in_enum_datatype_object_reference1() {
+    test_reference_in_enum_datatype::<ObjectReference1>();
+}
+
 #[cfg(feature = "1.12.1")]
 #[test]
 fn test_group_references_with_objectreference2() {
@@ -245,4 +305,11 @@ fn test_reference_errors_on_attribute_object_reference2() {
 #[test]
 fn test_reference_in_datatype_object_reference2() {
     test_reference_in_datatype::<ObjectReference2>();
+}
+
+// Compound datatypes can mix reference and enum fields without enum checks inspecting references.
+#[cfg(feature = "1.12.1")]
+#[test]
+fn test_reference_in_enum_datatype_object_reference2() {
+    test_reference_in_enum_datatype::<ObjectReference2>();
 }


### PR DESCRIPTION
Resolves #131

Add an enum compatibility check before HDF5 reads/writes constructs enums, rejecting conversions where the source enum has members missing from the destination type. 

This preserves HDF5 name-based enum conversion for compatible supersets and prevents unknown enum values from silently becoming invalid or wrong Rust enum variants.

The issue discusses which implementation makes sense, this implementation respects the spec and can be summerized as:
For enum source -> enum destination, every source member name must exist in destination.

relevant sections of the docs:
https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t__u_g.html#subsubsec_datatype_other_enum
https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t__u_g.html#subsec_datatype_transfer