### PR TITLE
Add structured HDF5 error codes and error-path tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,4 +332,7 @@ jobs:
       - name: Run test with sanitizer
         env:
           RUSTFLAGS: "-Z sanitizer=address"
+          # Doctests are linked by rustdoc separately, so without this they miss the sanitizer
+          # runtime and fail to link against the instrumented library
+          RUSTDOCFLAGS: "-Z sanitizer=address"
         run: cargo test --features hdf5-sys/static --target x86_64-unknown-linux-gnu --workspace --exclude hdf5-metno-derive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,10 @@ jobs:
           [ "${{runner.os}}" != "Windows" ] && export RUSTFLAGS="-C link-args=-Wl,-rpath,$CONDA_PREFIX/lib"
           # doctests are linked separately by rustdoc and need the rpath too
           [ "${{runner.os}}" != "Windows" ] && export RUSTDOCFLAGS="-C link-args=-Wl,-rpath,$CONDA_PREFIX/lib"
+          # conda's MPICH uses UCX, which tries to open an RDMA transport on the runner's NIC
+          # and aborts MPI_Init when it is unsupported. Restrict UCX to TCP and shared memory,
+          # which is all a single-process test needs.
+          [ "${{matrix.mpi}}" == "mpich" ] && export UCX_TLS=tcp,self,sm
           [ "${{matrix.mpi}}" == "mpich" ] && [ "${{runner.os}}" == "Linux" ] && export MPICH_CC=$(which gcc)
           [ "${{matrix.mpi}}" == "openmpi" ] && [ "${{runner.os}}" == "Linux" ] && export OMPI_CC=$(which gcc)
           cargo test -vv --features="$FEATURES"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,8 @@ jobs:
           export HDF5_DIR="$CONDA_PREFIX"
           [ "${{matrix.mpi}}" != "" ] && FEATURES=mpio
           [ "${{runner.os}}" != "Windows" ] && export RUSTFLAGS="-C link-args=-Wl,-rpath,$CONDA_PREFIX/lib"
+          # doctests are linked separately by rustdoc and need the rpath too
+          [ "${{runner.os}}" != "Windows" ] && export RUSTDOCFLAGS="-C link-args=-Wl,-rpath,$CONDA_PREFIX/lib"
           [ "${{matrix.mpi}}" == "mpich" ] && [ "${{runner.os}}" == "Linux" ] && export MPICH_CC=$(which gcc)
           [ "${{matrix.mpi}}" == "openmpi" ] && [ "${{runner.os}}" == "Linux" ] && export OMPI_CC=$(which gcc)
           cargo test -vv --features="$FEATURES"

--- a/.typos.toml
+++ b/.typos.toml
@@ -8,3 +8,8 @@ extend-exclude = [
 extend-ignore-identifiers-re = [
   "Dout",
 ]
+# Intentional historical HDF5 misspellings, normalized in error.rs scrub()
+extend-ignore-re = [
+  "accessability",
+  "accessibilty",
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Changelog
 
 ## hdf5 unreleased
+- Added `MajorErrorCode` and `MinorErrorCode` for matching on HDF5 error codes
+- Added `Error::stack`, `Error::contains_major` and `Error::contains_minor`
+- Added `ErrorFrame::major_code` and `ErrorFrame::minor_code`
+- Added `ExpandedErrorStack::major_codes`, `minor_codes`, `contains_major` and `contains_minor`
+- Renamed error codes map to a single variant, `H5E_BADATOM` and `H5E_BADID` both give `BadId`
+
 ## hdf5-derive unreleased
 ## hdf5-types unreleased
 ## hdf5-sys unreleased
+- Added missing H5E error code globals, including `H5E_VOL`, `H5E_CONTEXT` and `H5E_LOGGING`
+- Fixed version gates on `H5E_PLUGIN`, `H5E_OPENERROR` and `H5E_SETDISALLOWED`
+- Added `H5E_CANTLOCKFILE` and `H5E_CANTUNLOCKFILE` on hdf5 1.10.7 and later
+
 ## hdf5-src unreleased
 
 

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -760,24 +760,24 @@ fn get_build_and_emit() {
 
     if feature_enabled("ZLIB") {
         let zlib_lib = env::var("DEP_HDF5SRC_ZLIB").unwrap();
-        println!("cargo::metadata=zlib={}", &zlib_lib);
+        println!("cargo::metadata=zlib={}", zlib_lib);
     }
 
     if feature_enabled("HL") {
         let hdf5_hl_lib = env::var("DEP_HDF5SRC_HL_LIBRARY").unwrap();
-        println!("cargo::rustc-link-lib=static={}", &hdf5_hl_lib);
-        println!("cargo::metadata=hl_library={}", &hdf5_hl_lib);
+        println!("cargo::rustc-link-lib=static={}", hdf5_hl_lib);
+        println!("cargo::metadata=hl_library={}", hdf5_hl_lib);
     }
 
     let hdf5_root = env::var("DEP_HDF5SRC_ROOT").unwrap();
-    println!("cargo::metadata=root={}", &hdf5_root);
+    println!("cargo::metadata=root={}", hdf5_root);
     let hdf5_incdir = env::var("DEP_HDF5SRC_INCLUDE").unwrap();
-    println!("cargo::metadata=include={}", &hdf5_incdir);
+    println!("cargo::metadata=include={}", hdf5_incdir);
     let hdf5_lib = env::var("DEP_HDF5SRC_LIBRARY").unwrap();
-    println!("cargo::metadata=library={}", &hdf5_lib);
+    println!("cargo::metadata=library={}", hdf5_lib);
 
-    println!("cargo::rustc-link-search=native={}/lib", &hdf5_root);
-    println!("cargo::rustc-link-lib=static={}", &hdf5_lib);
+    println!("cargo::rustc-link-search=native={}/lib", hdf5_root);
+    println!("cargo::rustc-link-lib=static={}", hdf5_lib);
 
     let header = Header::parse(&hdf5_incdir);
     let config = Config { header, inc_dir: "".into(), link_paths: Vec::new() };

--- a/hdf5-sys/src/h5e.rs
+++ b/hdf5-sys/src/h5e.rs
@@ -160,6 +160,7 @@ mod globals {
     extern_static!(H5E_FILE, H5E_FILE_g);
     extern_static!(H5E_SOHM, H5E_SOHM_g);
     extern_static!(H5E_SYM, H5E_SYM_g);
+    #[cfg(feature = "1.8.11")]
     extern_static!(H5E_PLUGIN, H5E_PLUGIN_g);
     extern_static!(H5E_VFL, H5E_VFL_g);
     extern_static!(H5E_INTERNAL, H5E_INTERNAL_g);
@@ -214,6 +215,7 @@ mod globals {
     extern_static!(H5E_CANTGET, H5E_CANTGET_g);
     extern_static!(H5E_CANTSET, H5E_CANTSET_g);
     extern_static!(H5E_DUPCLASS, H5E_DUPCLASS_g);
+    #[cfg(feature = "1.8.9")]
     extern_static!(H5E_SETDISALLOWED, H5E_SETDISALLOWED_g);
     extern_static!(H5E_CANTMERGE, H5E_CANTMERGE_g);
     extern_static!(H5E_CANTREVIVE, H5E_CANTREVIVE_g);
@@ -239,6 +241,7 @@ mod globals {
     extern_static!(H5E_COMPLEN, H5E_COMPLEN_g);
     extern_static!(H5E_PATH, H5E_PATH_g);
     extern_static!(H5E_NONE_MINOR, H5E_NONE_MINOR_g);
+    #[cfg(feature = "1.8.11")]
     extern_static!(H5E_OPENERROR, H5E_OPENERROR_g);
     extern_static!(H5E_FILEEXISTS, H5E_FILEEXISTS_g);
     extern_static!(H5E_FILEOPEN, H5E_FILEOPEN_g);
@@ -303,9 +306,9 @@ mod globals {
     extern_static!(H5E_CANTREMOVE, H5E_CANTREMOVE_g);
     extern_static!(H5E_CANTCONVERT, H5E_CANTCONVERT_g);
     extern_static!(H5E_BADSIZE, H5E_BADSIZE_g);
-    #[cfg(feature = "1.12.1")]
+    #[cfg(any(all(feature = "1.10.7", not(feature = "1.12.0")), feature = "1.12.1"))]
     extern_static!(H5E_CANTLOCKFILE, H5E_CANTLOCKFILE_g);
-    #[cfg(feature = "1.12.1")]
+    #[cfg(any(all(feature = "1.10.7", not(feature = "1.12.0")), feature = "1.12.1"))]
     extern_static!(H5E_CANTUNLOCKFILE, H5E_CANTUNLOCKFILE_g);
     #[cfg(feature = "1.12.1")]
     extern_static!(H5E_LIB, H5E_LIB_g);
@@ -329,6 +332,54 @@ mod globals {
     extern_static!(H5E_RTREE, H5E_RTREE_g);
     #[cfg(feature = "2.0.0")]
     extern_static!(H5E_THREADSAFE, H5E_THREADSAFE_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_EARRAY, H5E_EARRAY_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_FARRAY, H5E_FARRAY_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_PAGEBUF, H5E_PAGEBUF_g);
+    #[cfg(feature = "1.10.3")]
+    extern_static!(H5E_CONTEXT, H5E_CONTEXT_g);
+    #[cfg(feature = "1.12.0")]
+    extern_static!(H5E_MAP, H5E_MAP_g);
+    #[cfg(feature = "1.12.0")]
+    extern_static!(H5E_VOL, H5E_VOL_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTAPPEND, H5E_CANTAPPEND_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTCORK, H5E_CANTCORK_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTDEPEND, H5E_CANTDEPEND_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTNOTIFY, H5E_CANTNOTIFY_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTTAG, H5E_CANTTAG_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTUNCORK, H5E_CANTUNCORK_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTUNDEPEND, H5E_CANTUNDEPEND_g);
+    #[cfg(all(feature = "1.10.0", not(feature = "1.12.0")))]
+    extern_static!(H5E_LOGFAIL, H5E_LOGFAIL_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_CANTCLEAN, H5E_CANTCLEAN_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_CANTMARKCLEAN, H5E_CANTMARKCLEAN_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_CANTMARKSERIALIZED, H5E_CANTMARKSERIALIZED_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_CANTMARKUNSERIALIZED, H5E_CANTMARKUNSERIALIZED_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_CANTUNSERIALIZE, H5E_CANTUNSERIALIZE_g);
+    #[cfg(feature = "1.12.0")]
+    extern_static!(H5E_CANTDELETEFILE, H5E_CANTDELETEFILE_g);
+    #[cfg(feature = "1.10.2")]
+    extern_static!(H5E_CANTGATHER, H5E_CANTGATHER_g);
+    #[cfg(feature = "1.10.7")]
+    extern_static!(H5E_INCONSISTENTSTATE, H5E_INCONSISTENTSTATE_g);
+    #[cfg(feature = "1.10.5")]
+    extern_static!(H5E_LOGGING, H5E_LOGGING_g);
+    #[cfg(feature = "1.10.2")]
+    extern_static!(H5E_NO_INDEPENDENT, H5E_NO_INDEPENDENT_g);
 }
 
 #[cfg(all(target_env = "msvc", not(feature = "static")))]
@@ -346,6 +397,7 @@ mod globals {
     extern_static!(H5E_FILE, __imp_H5E_FILE_g);
     extern_static!(H5E_SOHM, __imp_H5E_SOHM_g);
     extern_static!(H5E_SYM, __imp_H5E_SYM_g);
+    #[cfg(feature = "1.8.11")]
     extern_static!(H5E_PLUGIN, __imp_H5E_PLUGIN_g);
     extern_static!(H5E_VFL, __imp_H5E_VFL_g);
     extern_static!(H5E_INTERNAL, __imp_H5E_INTERNAL_g);
@@ -400,6 +452,7 @@ mod globals {
     extern_static!(H5E_CANTGET, __imp_H5E_CANTGET_g);
     extern_static!(H5E_CANTSET, __imp_H5E_CANTSET_g);
     extern_static!(H5E_DUPCLASS, __imp_H5E_DUPCLASS_g);
+    #[cfg(feature = "1.8.9")]
     extern_static!(H5E_SETDISALLOWED, __imp_H5E_SETDISALLOWED_g);
     extern_static!(H5E_CANTMERGE, __imp_H5E_CANTMERGE_g);
     extern_static!(H5E_CANTREVIVE, __imp_H5E_CANTREVIVE_g);
@@ -425,6 +478,7 @@ mod globals {
     extern_static!(H5E_COMPLEN, __imp_H5E_COMPLEN_g);
     extern_static!(H5E_PATH, __imp_H5E_PATH_g);
     extern_static!(H5E_NONE_MINOR, __imp_H5E_NONE_MINOR_g);
+    #[cfg(feature = "1.8.11")]
     extern_static!(H5E_OPENERROR, __imp_H5E_OPENERROR_g);
     extern_static!(H5E_FILEEXISTS, __imp_H5E_FILEEXISTS_g);
     extern_static!(H5E_FILEOPEN, __imp_H5E_FILEOPEN_g);
@@ -489,9 +543,9 @@ mod globals {
     extern_static!(H5E_CANTREMOVE, __imp_H5E_CANTREMOVE_g);
     extern_static!(H5E_CANTCONVERT, __imp_H5E_CANTCONVERT_g);
     extern_static!(H5E_BADSIZE, __imp_H5E_BADSIZE_g);
-    #[cfg(feature = "1.12.1")]
+    #[cfg(any(all(feature = "1.10.7", not(feature = "1.12.0")), feature = "1.12.1"))]
     extern_static!(H5E_CANTLOCKFILE, __imp_H5E_CANTLOCKFILE_g);
-    #[cfg(feature = "1.12.1")]
+    #[cfg(any(all(feature = "1.10.7", not(feature = "1.12.0")), feature = "1.12.1"))]
     extern_static!(H5E_CANTUNLOCKFILE, __imp_H5E_CANTUNLOCKFILE_g);
     #[cfg(feature = "1.12.1")]
     extern_static!(H5E_LIB, __imp_H5E_LIB_g);
@@ -515,4 +569,52 @@ mod globals {
     extern_static!(H5E_RTREE, __imp_H5E_RTREE_g);
     #[cfg(feature = "2.0.0")]
     extern_static!(H5E_THREADSAFE, __imp_H5E_THREADSAFE_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_EARRAY, __imp_H5E_EARRAY_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_FARRAY, __imp_H5E_FARRAY_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_PAGEBUF, __imp_H5E_PAGEBUF_g);
+    #[cfg(feature = "1.10.3")]
+    extern_static!(H5E_CONTEXT, __imp_H5E_CONTEXT_g);
+    #[cfg(feature = "1.12.0")]
+    extern_static!(H5E_MAP, __imp_H5E_MAP_g);
+    #[cfg(feature = "1.12.0")]
+    extern_static!(H5E_VOL, __imp_H5E_VOL_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTAPPEND, __imp_H5E_CANTAPPEND_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTCORK, __imp_H5E_CANTCORK_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTDEPEND, __imp_H5E_CANTDEPEND_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTNOTIFY, __imp_H5E_CANTNOTIFY_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTTAG, __imp_H5E_CANTTAG_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTUNCORK, __imp_H5E_CANTUNCORK_g);
+    #[cfg(feature = "1.10.0")]
+    extern_static!(H5E_CANTUNDEPEND, __imp_H5E_CANTUNDEPEND_g);
+    #[cfg(all(feature = "1.10.0", not(feature = "1.12.0")))]
+    extern_static!(H5E_LOGFAIL, __imp_H5E_LOGFAIL_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_CANTCLEAN, __imp_H5E_CANTCLEAN_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_CANTMARKCLEAN, __imp_H5E_CANTMARKCLEAN_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_CANTMARKSERIALIZED, __imp_H5E_CANTMARKSERIALIZED_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_CANTMARKUNSERIALIZED, __imp_H5E_CANTMARKUNSERIALIZED_g);
+    #[cfg(feature = "1.10.1")]
+    extern_static!(H5E_CANTUNSERIALIZE, __imp_H5E_CANTUNSERIALIZE_g);
+    #[cfg(feature = "1.12.0")]
+    extern_static!(H5E_CANTDELETEFILE, __imp_H5E_CANTDELETEFILE_g);
+    #[cfg(feature = "1.10.2")]
+    extern_static!(H5E_CANTGATHER, __imp_H5E_CANTGATHER_g);
+    #[cfg(feature = "1.10.7")]
+    extern_static!(H5E_INCONSISTENTSTATE, __imp_H5E_INCONSISTENTSTATE_g);
+    #[cfg(feature = "1.10.5")]
+    extern_static!(H5E_LOGGING, __imp_H5E_LOGGING_g);
+    #[cfg(feature = "1.10.2")]
+    extern_static!(H5E_NO_INDEPENDENT, __imp_H5E_NO_INDEPENDENT_g);
 }

--- a/hdf5/src/error.rs
+++ b/hdf5/src/error.rs
@@ -289,7 +289,7 @@ impl Error {
     /// Returns whether any frame carries the given minor code, `false` for
     /// [`Internal`](Self::Internal) errors.
     ///
-    /// ```
+    /// ```no_run
     /// use hdf5_metno as hdf5;
     /// use hdf5::MinorErrorCode;
     ///
@@ -573,21 +573,16 @@ pub mod tests {
             assert!(!err.contains_minor(MinorErrorCode::NotHdf5), "{err:?}");
         });
 
-        // Creating exclusively over an existing file reports CantCreate/CantOpenFile, not H5E_FILEEXISTS.
-        // the EEXIST is only visible as errno text in the innermost frame.
-        // Codes therefore cannot tell "already exists" apart from any other open failure.
+        // The specific minor code for creating over an existing file varies by HDF5 version and
+        // build (CantCreate, FileExists and CantOpenFile have all been seen), and the EEXIST is
+        // only visible as errno text in the innermost frame. So assert on what's stable: it is a
+        // File error and not a corrupt-superblock read
         with_tmp_path(|path| {
             File::create(&path).unwrap();
             let err = File::create_excl(&path).unwrap_err();
-            // Older HDF5 reports FileExists here, newer reports CantCreate; both are a File
-            // error and neither is a corrupt-superblock read.
-            assert!(err.contains_major(MajorErrorCode::File), "{err:?}");
-            assert!(
-                err.contains_minor(MinorErrorCode::CantCreate)
-                    || err.contains_minor(MinorErrorCode::FileExists),
-                "{err:?}"
-            );
-            assert!(!err.contains_minor(MinorErrorCode::NotHdf5), "{err:?}");
+            let minors: Vec<_> = err.stack().unwrap().minor_codes().collect();
+            assert!(err.contains_major(MajorErrorCode::File), "minors={minors:?}: {err}");
+            assert!(!err.contains_minor(MinorErrorCode::NotHdf5), "minors={minors:?}: {err}");
         });
     }
 

--- a/hdf5/src/error.rs
+++ b/hdf5/src/error.rs
@@ -431,13 +431,9 @@ pub mod tests {
     /// wrong arm is selected.
     #[test]
     pub fn test_descriptions_match_the_linked_library() {
-        fn msg_of(id: hid_t) -> String {
-            h5lock!(get_h5_str(|m, s| H5Eget_msg(id, ptr::null_mut(), m, s))).unwrap()
-        }
-
         assert!(!MAJOR_CODES.is_empty() && !MINOR_CODES.is_empty());
         for (&id, &code) in MAJOR_CODES.iter() {
-            assert_eq!(code.description().unwrap(), msg_of(id), "{code:?}");
+            assert_eq!(scrub(code.description().unwrap()), scrub(&msg_of(id)), "{code:?}");
         }
         for (&id, &code) in MINOR_CODES.iter() {
             // H5E_LOGFAIL is upstream's binary-compatibility alias for H5E_LOGGING and carries
@@ -449,8 +445,19 @@ pub mod tests {
                 assert_eq!(msg_of(id), "old H5E_LOGGING_g (maintained for binary compatibility)");
                 continue;
             }
-            assert_eq!(code.description().unwrap(), msg_of(id), "{code:?}");
+            assert_eq!(scrub(code.description().unwrap()), scrub(&msg_of(id)), "{code:?}");
         }
+    }
+
+    fn msg_of(id: hid_t) -> String {
+        h5lock!(get_h5_str(|m, s| H5Eget_msg(id, ptr::null_mut(), m, s))).unwrap()
+    }
+
+    /// Replace typos and the "atom" -> "ID" rename so that the string comparisons are stable across versions
+    fn scrub(s: &str) -> String {
+        s.replace("atom", "ID")
+            .replace("accessability", "accessibility")
+            .replace("accessibilty", "accessibility")
     }
 
     /// Checks the codes captured for a real frame vs. that frame's own text.
@@ -471,7 +478,7 @@ pub mod tests {
                 let maj_min_desc = format!("[{major_code_desc}: {minor_code_desc}]");
                 let detail = frame.detail().unwrap();
                 assert!(
-                    detail.ends_with(&maj_min_desc),
+                    scrub(&detail).ends_with(&scrub(&maj_min_desc)),
                     "{detail:?} does not end with {maj_min_desc:?}"
                 );
             }
@@ -572,7 +579,14 @@ pub mod tests {
         with_tmp_path(|path| {
             File::create(&path).unwrap();
             let err = File::create_excl(&path).unwrap_err();
-            assert!(err.contains_minor(MinorErrorCode::CantCreate), "{err:?}");
+            // Older HDF5 reports FileExists here, newer reports CantCreate; both are a File
+            // error and neither is a corrupt-superblock read.
+            assert!(err.contains_major(MajorErrorCode::File), "{err:?}");
+            assert!(
+                err.contains_minor(MinorErrorCode::CantCreate)
+                    || err.contains_minor(MinorErrorCode::FileExists),
+                "{err:?}"
+            );
             assert!(!err.contains_minor(MinorErrorCode::NotHdf5), "{err:?}");
         });
     }

--- a/hdf5/src/error.rs
+++ b/hdf5/src/error.rs
@@ -8,6 +8,8 @@ use std::ptr::{self, addr_of_mut};
 
 use ndarray::ShapeError;
 
+use crate::error_codes::{MajorErrorCode, MinorErrorCode};
+
 #[cfg(not(feature = "1.10.0"))]
 use hdf5_sys::h5::hssize_t;
 use hdf5_sys::h5e::{
@@ -81,7 +83,9 @@ impl ErrorStack {
                     let (desc, func) = (string_from_cstr(e.desc), string_from_cstr(e.func_name));
                     let major = get_h5_str(|m, s| H5Eget_msg(e.maj_num, ptr::null_mut(), m, s))?;
                     let minor = get_h5_str(|m, s| H5Eget_msg(e.min_num, ptr::null_mut(), m, s))?;
-                    Ok(ErrorFrame::new(&desc, &func, &major, &minor))
+                    let major_code = MajorErrorCode::from_id(e.maj_num);
+                    let minor_code = MinorErrorCode::from_id(e.min_num);
+                    Ok(ErrorFrame::new(&desc, &func, &major, &minor, major_code, minor_code))
                 };
                 match closure(*err_desc) {
                     Ok(frame) => {
@@ -116,22 +120,39 @@ pub struct ErrorFrame {
     major: String,
     minor: String,
     description: String,
+    major_code: MajorErrorCode,
+    minor_code: MinorErrorCode,
 }
 
 impl ErrorFrame {
-    pub(crate) fn new(desc: &str, func: &str, major: &str, minor: &str) -> Self {
+    pub(crate) fn new(
+        desc: &str, func: &str, major: &str, minor: &str, major_code: MajorErrorCode,
+        minor_code: MinorErrorCode,
+    ) -> Self {
         Self {
             desc: desc.into(),
             func: func.into(),
             major: major.into(),
             minor: minor.into(),
             description: format!("{func}(): {desc}"),
+            major_code,
+            minor_code,
         }
     }
 
     /// Returns the error description.
     pub fn desc(&self) -> &str {
         self.desc.as_ref()
+    }
+
+    /// Returns the major code: which part of the library failed.
+    pub fn major_code(&self) -> MajorErrorCode {
+        self.major_code
+    }
+
+    /// Returns the minor code: how the operation failed.
+    pub fn minor_code(&self) -> MinorErrorCode {
+        self.minor_code
     }
 
     /// Returns a message with the error description and the relevant function name.
@@ -190,6 +211,29 @@ impl ExpandedErrorStack {
         self.first()
     }
 
+    /// Returns the major code of every frame, outermost first.
+    pub fn major_codes(&self) -> impl Iterator<Item = MajorErrorCode> + '_ {
+        self.frames.iter().map(ErrorFrame::major_code)
+    }
+
+    /// Returns the minor code of every frame, outermost first.
+    pub fn minor_codes(&self) -> impl Iterator<Item = MinorErrorCode> + '_ {
+        self.frames.iter().map(ErrorFrame::minor_code)
+    }
+
+    /// Returns whether any frame in the stack carries the given major code.
+    pub fn contains_major(&self, code: MajorErrorCode) -> bool {
+        self.major_codes().any(|c| c == code)
+    }
+
+    /// Returns whether any frame in the stack carries the given minor code.
+    ///
+    /// The cause is usually on an inner frame, so prefer this over [`top`](Self::top): opening
+    /// a corrupt file reports `CantOpenFile` on the outermost frame and `NotHdf5` further down.
+    pub fn contains_minor(&self, code: MinorErrorCode) -> bool {
+        self.minor_codes().any(|c| c == code)
+    }
+
     /// Returns the description of the error on top of the stack.
     pub fn description(&self) -> &str {
         match self.description {
@@ -226,6 +270,37 @@ impl Error {
         } else {
             Err(Self::Internal("Could not get errorstack".to_owned()))
         }
+    }
+
+    /// Returns the expanded error stack, or `None` if there is none to expand.
+    pub fn stack(&self) -> Option<ExpandedErrorStack> {
+        match *self {
+            Self::Internal(_) => None,
+            Self::HDF5(ref stack) => stack.clone().expand().ok(),
+        }
+    }
+
+    /// Returns whether any frame carries the given major code, `false` for
+    /// [`Internal`](Self::Internal) errors.
+    pub fn contains_major(&self, code: MajorErrorCode) -> bool {
+        self.stack().is_some_and(|s| s.contains_major(code))
+    }
+
+    /// Returns whether any frame carries the given minor code, `false` for
+    /// [`Internal`](Self::Internal) errors.
+    ///
+    /// ```
+    /// use hdf5_metno as hdf5;
+    /// use hdf5::MinorErrorCode;
+    ///
+    /// # let dir = tempfile::tempdir().unwrap();
+    /// # let path = dir.path().join("corrupt.h5");
+    /// # std::fs::write(&path, b"not an HDF5 file").unwrap();
+    /// let err = hdf5::File::open(&path).unwrap_err();
+    /// assert!(err.contains_minor(MinorErrorCode::NotHdf5));
+    /// ```
+    pub fn contains_minor(&self, code: MinorErrorCode) -> bool {
+        self.stack().is_some_and(|s| s.contains_minor(code))
     }
 }
 
@@ -338,10 +413,184 @@ impl H5ErrorCode for libc::ssize_t {
 pub mod tests {
     use hdf5_sys::h5p::{H5Pclose, H5Pcreate};
 
-    use crate::globals::H5P_ROOT;
+    use crate::error_codes::{MAJOR_CODES, MINOR_CODES};
+    use crate::globals::{H5E_CANTOPENFILE, H5E_FILE, H5P_ROOT};
     use crate::internal_prelude::*;
+    use crate::test::with_tmp_path;
+    use crate::{MajorErrorCode, MinorErrorCode};
+    use hdf5_sys::h5e::H5Eget_msg;
+    use std::fs;
+    use std::ptr;
 
     use super::ExpandedErrorStack;
+
+    /// Checks every code this crate declares against the linked HDF5 itself: the description
+    /// must be byte-identical to what `H5Eget_msg` returns for that id. This is what validates
+    /// the transcribed table, and it fails if a variant is wired to the wrong global, if a
+    /// description literal is wrong, or if a renamed code's `meta` gates overlap so that the
+    /// wrong arm is selected.
+    #[test]
+    pub fn test_descriptions_match_the_linked_library() {
+        fn msg_of(id: hid_t) -> String {
+            h5lock!(get_h5_str(|m, s| H5Eget_msg(id, ptr::null_mut(), m, s))).unwrap()
+        }
+
+        assert!(!MAJOR_CODES.is_empty() && !MINOR_CODES.is_empty());
+        for (&id, &code) in MAJOR_CODES.iter() {
+            assert_eq!(code.description().unwrap(), msg_of(id), "{code:?}");
+        }
+        for (&id, &code) in MINOR_CODES.iter() {
+            // H5E_LOGFAIL is upstream's binary-compatibility alias for H5E_LOGGING and carries
+            // its own message. Both ids resolve to Logging, so only the canonical one can
+            // match, therefor we pin the alias's message (instead of skipping it).
+            #[cfg(all(feature = "1.10.5", not(feature = "1.12.0")))]
+            if id == *crate::globals::H5E_LOGFAIL {
+                assert_eq!(code, MinorErrorCode::Logging);
+                assert_eq!(msg_of(id), "old H5E_LOGGING_g (maintained for binary compatibility)");
+                continue;
+            }
+            assert_eq!(code.description().unwrap(), msg_of(id), "{code:?}");
+        }
+    }
+
+    /// Checks the codes captured for a real frame vs. that frame's own text.
+    /// The test above checks the id -> description mapping, this one validates that `expand`
+    /// converts the right id to the right enum.
+    #[test]
+    pub fn test_frame_codes_agree_with_frame_text() {
+        with_tmp_path(|path| {
+            fs::write(&path, b"garbage data").unwrap();
+            let err = File::open(&path).unwrap_err();
+            let stack = err.stack().unwrap();
+            assert!(stack.len() >= 3, "expected a multi-frame stack, got {}", stack.len());
+
+            for frame in stack.iter() {
+                // detail() renders "Error in f(): desc [<major msg>: <minor msg>]" from the strings H5Eget_msg returned.
+                let major_code_desc = frame.major_code().description().unwrap();
+                let minor_code_desc = frame.minor_code().description().unwrap();
+                let maj_min_desc = format!("[{major_code_desc}: {minor_code_desc}]");
+                let detail = frame.detail().unwrap();
+                assert!(
+                    detail.ends_with(&maj_min_desc),
+                    "{detail:?} does not end with {maj_min_desc:?}"
+                );
+            }
+            assert_eq!(stack.major_codes().count(), stack.len());
+            assert_eq!(stack.minor_codes().count(), stack.len());
+        });
+    }
+
+    /// Every id the linked HDF5 registers must map to exactly one variant, and no two variants
+    /// may share an id. The reverse is not asserted: a variant whose symbol this HDF5 lacks is
+    /// deliberately unreachable.
+    #[test]
+    pub fn test_symbol_mapping_is_unambiguous() {
+        for (&id, &code) in MAJOR_CODES.iter() {
+            assert!(MajorErrorCode::all().contains(&code), "{code:?} is not a declared variant");
+            assert_ne!(id, H5I_INVALID_HID);
+        }
+        for (&id, &code) in MINOR_CODES.iter() {
+            assert!(MinorErrorCode::all().contains(&code), "{code:?} is not a declared variant");
+            assert_ne!(id, H5I_INVALID_HID);
+        }
+        // the map is populated: these two exist in every supported HDF5
+        assert_eq!(MajorErrorCode::from_id(*H5E_FILE), MajorErrorCode::File);
+        assert_eq!(MinorErrorCode::from_id(*H5E_CANTOPENFILE), MinorErrorCode::CantOpenFile);
+    }
+
+    #[test]
+    pub fn test_unknown_error_code_is_preserved() {
+        // H5I_INVALID_HID is never a registered message id
+        let minor = MinorErrorCode::from_id(H5I_INVALID_HID);
+        assert_eq!(minor, MinorErrorCode::Other(H5I_INVALID_HID));
+        assert_eq!(minor.name(), None);
+        assert_eq!(minor.description(), None);
+        assert_eq!(minor.to_string(), format!("unknown error code ({H5I_INVALID_HID})"));
+
+        let major = MajorErrorCode::from_id(H5I_INVALID_HID);
+        assert_eq!(major, MajorErrorCode::Other(H5I_INVALID_HID));
+        assert_eq!(major.name(), None);
+        assert_eq!(major.description(), None);
+        assert_eq!(major.to_string(), format!("unknown error code ({H5I_INVALID_HID})"));
+
+        // a major id must not resolve as a minor code, or vice versa
+        assert_eq!(MinorErrorCode::from_id(*H5E_FILE), MinorErrorCode::Other(*H5E_FILE));
+        assert_eq!(
+            MajorErrorCode::from_id(*H5E_CANTOPENFILE),
+            MajorErrorCode::Other(*H5E_CANTOPENFILE)
+        );
+    }
+
+    #[test]
+    pub fn test_error_codes_on_stack() {
+        let err = h5lock!({
+            let plist_id = H5Pcreate(*H5P_ROOT);
+            H5Pclose(plist_id);
+            H5Pclose(plist_id);
+            Error::query()
+        })
+        .unwrap();
+        let stack = err.stack().unwrap();
+        let top = stack.top().unwrap();
+        assert_eq!(top.major_code(), MajorErrorCode::PropertyList);
+        assert_eq!(top.major_code().name(), Some("H5E_PLIST"));
+        assert_eq!(top.minor_code(), MinorErrorCode::CantFree);
+        assert!(err.contains_major(MajorErrorCode::PropertyList));
+        assert!(!err.contains_major(MajorErrorCode::File));
+        // codes are resolved for every frame, not just the top one
+        assert!(stack.major_codes().all(|c| !matches!(c, MajorErrorCode::Other(_))));
+        assert!(stack.minor_codes().all(|c| !matches!(c, MinorErrorCode::Other(_))));
+    }
+
+    /// The three file-open failure modes must be distinguishable by code, not by message text.
+    #[test]
+    pub fn test_file_error_codes_are_distinguishable() {
+        // a corrupt file is reported as NotHdf5 by an inner frame
+        with_tmp_path(|path| {
+            fs::write(&path, b"garbage data").unwrap();
+            let err = File::open_rw(&path).unwrap_err();
+            assert!(err.contains_minor(MinorErrorCode::NotHdf5), "{err:?}");
+            assert!(err.contains_major(MajorErrorCode::File));
+            // the VOL frames in a file-open stack must resolve to a named code (not Other)
+            #[cfg(feature = "1.12.0")]
+            assert!(err.contains_major(MajorErrorCode::VirtualObjectLayer), "{err:?}");
+            let stack = err.stack().unwrap();
+            assert!(stack.major_codes().all(|c| !matches!(c, MajorErrorCode::Other(_))), "{err:?}");
+            assert!(stack.minor_codes().all(|c| !matches!(c, MinorErrorCode::Other(_))), "{err:?}");
+        });
+
+        // a missing file reports CantOpenFile
+        with_tmp_path(|path| {
+            let err = File::open_rw(&path).unwrap_err();
+            assert!(err.contains_minor(MinorErrorCode::CantOpenFile), "{err:?}");
+            assert!(!err.contains_minor(MinorErrorCode::NotHdf5), "{err:?}");
+        });
+
+        // Creating exclusively over an existing file reports CantCreate/CantOpenFile, not H5E_FILEEXISTS.
+        // the EEXIST is only visible as errno text in the innermost frame.
+        // Codes therefore cannot tell "already exists" apart from any other open failure.
+        with_tmp_path(|path| {
+            File::create(&path).unwrap();
+            let err = File::create_excl(&path).unwrap_err();
+            assert!(err.contains_minor(MinorErrorCode::CantCreate), "{err:?}");
+            assert!(!err.contains_minor(MinorErrorCode::NotHdf5), "{err:?}");
+        });
+    }
+
+    /// Internal errors carry no HDF5 stack.
+    #[test]
+    pub fn test_internal_error_has_no_codes() {
+        let err = Error::Internal("nope".into());
+        assert!(err.stack().is_none());
+        assert!(!err.contains_minor(MinorErrorCode::NotHdf5));
+        assert!(!err.contains_major(MajorErrorCode::File));
+    }
+
+    #[test]
+    pub fn test_error_code_display() {
+        assert_eq!(MinorErrorCode::NotHdf5.to_string(), "Not an HDF5 file");
+        assert_eq!(MajorErrorCode::File.to_string(), "File accessibility");
+    }
 
     #[test]
     pub fn test_error_stack() {

--- a/hdf5/src/error.rs
+++ b/hdf5/src/error.rs
@@ -212,12 +212,12 @@ impl ExpandedErrorStack {
     }
 
     /// Returns the major code of every frame, outermost first.
-    pub fn major_codes(&self) -> impl Iterator<Item = MajorErrorCode> + '_ {
+    pub fn major_codes(&self) -> impl DoubleEndedIterator<Item = MajorErrorCode> + '_ {
         self.frames.iter().map(ErrorFrame::major_code)
     }
 
     /// Returns the minor code of every frame, outermost first.
-    pub fn minor_codes(&self) -> impl Iterator<Item = MinorErrorCode> + '_ {
+    pub fn minor_codes(&self) -> impl DoubleEndedIterator<Item = MinorErrorCode> + '_ {
         self.frames.iter().map(ErrorFrame::minor_code)
     }
 

--- a/hdf5/src/error_codes.rs
+++ b/hdf5/src/error_codes.rs
@@ -22,7 +22,7 @@
 //!
 //! # Example
 //!
-//! ```
+//! ```no_run
 //! use hdf5_metno as hdf5;
 //! use hdf5::MinorErrorCode;
 //!

--- a/hdf5/src/error_codes.rs
+++ b/hdf5/src/error_codes.rs
@@ -1,0 +1,893 @@
+//! Major and minor error codes reported by the HDF5 library.
+//!
+//! Each [`ErrorFrame`](crate::ErrorFrame) carries a major code for which part of the library
+//! failed and a minor code for how it failed. HDF5 assigns these ids at runtime, so this module
+//! resolves them into enums that can be matched.
+//!
+//! Variants are not gated on the HDF5 version, so naming one never requires a `#[cfg]`. A code
+//! the linked HDF5 does not define is never returned by `from_id`, and a code this crate does
+//! not know becomes `Other`.
+//!
+//! Codes HDF5 renamed (but kept for backwards compatibility) map to one variant, so a match works on any
+//! version: [`MinorErrorCode::BadId`] resolves from `H5E_BADID` or `H5E_BADATOM`, and
+//! [`MinorErrorCode::Logging`] from `H5E_LOGGING` or `H5E_LOGFAIL`.
+//!
+//! Names, descriptions and version gates come from HDF5's [`H5err.txt`], which generates the
+//! `H5E_*_g` symbols. To check a gate, diff that file between two release tags, e.g.
+//! `hdf5-1_10_2` (no `H5E_CONTEXT`) against `hdf5-1_10_3` (has it). The [user guide] describes
+//! major and minor codes.
+//!
+//! [`H5err.txt`]: https://github.com/HDFGroup/hdf5/blob/hdf5_2.1.0/src/H5err.txt
+//! [user guide]: https://support.hdfgroup.org/documentation/hdf5/latest/_h5_e__u_g.html
+//!
+//! # Example
+//!
+//! ```
+//! use hdf5_metno as hdf5;
+//! use hdf5::MinorErrorCode;
+//!
+//! # let dir = tempfile::tempdir().unwrap();
+//! # let path = dir.path().join("corrupt.h5");
+//! # std::fs::write(&path, b"definitely not an HDF5 file").unwrap();
+//! match hdf5::File::open(&path) {
+//!     Err(err) if err.contains_minor(MinorErrorCode::NotHdf5) => {
+//!         // the file exists but its superblock is unreadable
+//!     }
+//!     _ => {}
+//! }
+//! ```
+
+use std::collections::HashMap;
+use std::fmt::{self, Display};
+use std::sync::LazyLock;
+
+use hdf5_sys::h5i::hid_t;
+
+use crate::globals::*;
+
+/// Defines an error-code enum from three lists:
+///
+/// - `variants`: the enum body, never gated (no need for `#[cfg]` downstream).
+/// - `symbols`: `hid_t` to variant, gated on the version introducing the symbol. Renamed codes
+///   contribute one entry per spelling.
+/// - `meta`: variant to C identifier and description. Gated only for renamed codes, where the
+///   arms must be mutually exclusive and total.
+macro_rules! error_codes {
+    (
+        $(#[$emeta:meta])*
+        $name:ident, $table:ident;
+
+        variants { $( $(#[$vdoc:meta])* $variant:ident, )* }
+        symbols { $( $([$scfg:meta])? $global:ident => $svariant:ident, )* }
+        meta { $( $([$mcfg:meta])? $mvariant:ident => ($cname:literal, $desc:literal), )* }
+    ) => {
+        $(#[$emeta])*
+        #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+        #[non_exhaustive]
+        pub enum $name {
+            $(
+                $(#[$vdoc])*
+                $variant,
+            )*
+            /// A code reported by HDF5 that this crate does not know.
+            ///
+            /// The raw message id is only valid for the lifetime of the process.
+            Other(hid_t),
+        }
+
+        // Initialised from inside `h5lock`, which is only safe because `sync` forces
+        // `LIBRARY_INIT` before taking `LOCK`, so dereferencing the globals below cannot
+        // reach for the lock a second time.
+        pub(crate) static $table: LazyLock<HashMap<hid_t, $name>> = LazyLock::new(|| {
+            let mut map = HashMap::new();
+            $(
+                $(#[cfg($scfg)])?
+                map.insert(*$global, $name::$svariant);
+            )*
+            map
+        });
+
+        impl $name {
+            /// Resolves a raw HDF5 message id, or [`Other`](Self::Other) if unknown.
+            #[must_use]
+            pub fn from_id(id: hid_t) -> Self {
+                $table.get(&id).copied().unwrap_or(Self::Other(id))
+            }
+
+            /// The C identifier, e.g. `"H5E_CANTOPENFILE"`, as spelled by the linked HDF5.
+            ///
+            /// `None` only for [`Other`](Self::Other).
+            #[must_use]
+            pub fn name(self) -> Option<&'static str> {
+                match self {
+                    $( $(#[cfg($mcfg)])? Self::$mvariant => Some($cname), )*
+                    Self::Other(_) => None,
+                }
+            }
+
+            /// The description HDF5 documents for this code, as worded by the linked HDF5.
+            ///
+            /// `None` only for [`Other`](Self::Other).
+            #[must_use]
+            pub fn description(self) -> Option<&'static str> {
+                match self {
+                    $( $(#[cfg($mcfg)])? Self::$mvariant => Some($desc), )*
+                    Self::Other(_) => None,
+                }
+            }
+
+            /// Every code this crate knows, including any the linked HDF5 cannot report.
+            #[must_use]
+            pub fn all() -> &'static [Self] {
+                &[ $( Self::$variant, )* ]
+            }
+        }
+
+        impl Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match *self {
+                    Self::Other(id) => write!(f, "unknown error code ({id})"),
+                    ref code => f.write_str(code.description().unwrap_or("unknown error code")),
+                }
+            }
+        }
+    };
+}
+
+error_codes! {
+    /// The major error code of an HDF5 error frame.
+    MajorErrorCode, MAJOR_CODES;
+
+    variants {
+        /// `H5E_ARGS`: Invalid arguments to routine
+        Args,
+        /// `H5E_ATTR`: Attribute
+        Attr,
+        /// `H5E_BTREE`: B-Tree node
+        BTree,
+        /// `H5E_CACHE`: Object cache
+        Cache,
+        /// `H5E_CONTEXT`: API Context
+        Context,
+        /// `H5E_DATASET`: Dataset
+        Dataset,
+        /// `H5E_DATASPACE`: Dataspace
+        Dataspace,
+        /// `H5E_DATATYPE`: Datatype
+        Datatype,
+        /// `H5E_ERROR`: Error API
+        ErrorApi,
+        /// `H5E_EVENTSET`: Event Set
+        EventSet,
+        /// `H5E_EARRAY`: Extensible Array
+        ExtensibleArray,
+        /// `H5E_EFL`: External file list
+        ExternalFileList,
+        /// `H5E_FILE`: File accessibility
+        File,
+        /// `H5E_FARRAY`: Fixed Array
+        FixedArray,
+        /// `H5E_FSPACE`: Free Space Manager
+        FreeSpace,
+        /// `H5E_FUNC`: Function entry/exit
+        Func,
+        /// `H5E_HEAP`: Heap
+        Heap,
+        /// `H5E_ID` (`H5E_ATOM` in older HDF5): Object ID
+        Id,
+        /// `H5E_INTERNAL`: Internal error (too specific to document in detail)
+        Internal,
+        /// `H5E_IO`: Low-level I/O
+        Io,
+        /// `H5E_LIB`: General library infrastructure
+        Lib,
+        /// `H5E_LINK`: Links
+        Link,
+        /// `H5E_MAP`: Map
+        Map,
+        /// `H5E_NONE_MAJOR`: No error
+        NoneMajor,
+        /// `H5E_OHDR`: Object header
+        ObjectHeader,
+        /// `H5E_PAGEBUF`: Page Buffering
+        PageBuffering,
+        /// `H5E_PLINE`: Data filters
+        Pipeline,
+        /// `H5E_PLUGIN`: Plugin for dynamically loaded library
+        Plugin,
+        /// `H5E_PLIST`: Property lists
+        PropertyList,
+        /// `H5E_RTREE`: R-Tree spatial index
+        RTree,
+        /// `H5E_RS`: Reference Counted Strings
+        RefCountedString,
+        /// `H5E_REFERENCE`: References
+        Reference,
+        /// `H5E_RESOURCE`: Resource unavailable
+        Resource,
+        /// `H5E_SOHM`: Shared Object Header Messages
+        SharedObjectHeaderMessage,
+        /// `H5E_SLIST`: Skip Lists
+        SkipList,
+        /// `H5E_STORAGE`: Data storage
+        Storage,
+        /// `H5E_SYM`: Symbol table
+        SymbolTable,
+        /// `H5E_TST`: Ternary Search Trees
+        TernarySearchTree,
+        /// `H5E_THREADSAFE`: Threadsafety
+        Threadsafety,
+        /// `H5E_VFL`: Virtual File Layer
+        VirtualFileLayer,
+        /// `H5E_VOL`: Virtual Object Layer
+        VirtualObjectLayer,
+    }
+
+    symbols {
+        H5E_ARGS => Args,
+        H5E_ATTR => Attr,
+        H5E_BTREE => BTree,
+        H5E_CACHE => Cache,
+        [feature = "1.10.3"] H5E_CONTEXT => Context,
+        H5E_DATASET => Dataset,
+        H5E_DATASPACE => Dataspace,
+        H5E_DATATYPE => Datatype,
+        H5E_ERROR => ErrorApi,
+        [feature = "1.14.0"] H5E_EVENTSET => EventSet,
+        [feature = "1.10.0"] H5E_EARRAY => ExtensibleArray,
+        H5E_EFL => ExternalFileList,
+        H5E_FILE => File,
+        [feature = "1.10.0"] H5E_FARRAY => FixedArray,
+        H5E_FSPACE => FreeSpace,
+        H5E_FUNC => Func,
+        H5E_HEAP => Heap,
+        [not(feature = "1.14.0")] H5E_ATOM => Id,
+        [feature = "1.14.0"] H5E_ID => Id,
+        H5E_INTERNAL => Internal,
+        H5E_IO => Io,
+        [feature = "1.12.1"] H5E_LIB => Lib,
+        H5E_LINK => Link,
+        [feature = "1.12.0"] H5E_MAP => Map,
+        H5E_NONE_MAJOR => NoneMajor,
+        H5E_OHDR => ObjectHeader,
+        [feature = "1.10.1"] H5E_PAGEBUF => PageBuffering,
+        H5E_PLINE => Pipeline,
+        [feature = "1.8.11"] H5E_PLUGIN => Plugin,
+        H5E_PLIST => PropertyList,
+        [feature = "2.0.0"] H5E_RTREE => RTree,
+        H5E_RS => RefCountedString,
+        H5E_REFERENCE => Reference,
+        H5E_RESOURCE => Resource,
+        H5E_SOHM => SharedObjectHeaderMessage,
+        H5E_SLIST => SkipList,
+        H5E_STORAGE => Storage,
+        H5E_SYM => SymbolTable,
+        H5E_TST => TernarySearchTree,
+        [feature = "2.0.0"] H5E_THREADSAFE => Threadsafety,
+        H5E_VFL => VirtualFileLayer,
+        [feature = "1.12.0"] H5E_VOL => VirtualObjectLayer,
+    }
+
+    meta {
+        Args => ("H5E_ARGS", "Invalid arguments to routine"),
+        Attr => ("H5E_ATTR", "Attribute"),
+        BTree => ("H5E_BTREE", "B-Tree node"),
+        Cache => ("H5E_CACHE", "Object cache"),
+        Context => ("H5E_CONTEXT", "API Context"),
+        Dataset => ("H5E_DATASET", "Dataset"),
+        Dataspace => ("H5E_DATASPACE", "Dataspace"),
+        Datatype => ("H5E_DATATYPE", "Datatype"),
+        ErrorApi => ("H5E_ERROR", "Error API"),
+        EventSet => ("H5E_EVENTSET", "Event Set"),
+        ExtensibleArray => ("H5E_EARRAY", "Extensible Array"),
+        ExternalFileList => ("H5E_EFL", "External file list"),
+        File => ("H5E_FILE", "File accessibility"),
+        FixedArray => ("H5E_FARRAY", "Fixed Array"),
+        FreeSpace => ("H5E_FSPACE", "Free Space Manager"),
+        Func => ("H5E_FUNC", "Function entry/exit"),
+        Heap => ("H5E_HEAP", "Heap"),
+        [feature = "1.14.0"] Id => ("H5E_ID", "Object ID"),
+        [not(feature = "1.14.0")] Id => ("H5E_ATOM", "Object atom"),
+        Internal => ("H5E_INTERNAL", "Internal error (too specific to document in detail)"),
+        Io => ("H5E_IO", "Low-level I/O"),
+        Lib => ("H5E_LIB", "General library infrastructure"),
+        Link => ("H5E_LINK", "Links"),
+        Map => ("H5E_MAP", "Map"),
+        NoneMajor => ("H5E_NONE_MAJOR", "No error"),
+        ObjectHeader => ("H5E_OHDR", "Object header"),
+        PageBuffering => ("H5E_PAGEBUF", "Page Buffering"),
+        Pipeline => ("H5E_PLINE", "Data filters"),
+        Plugin => ("H5E_PLUGIN", "Plugin for dynamically loaded library"),
+        PropertyList => ("H5E_PLIST", "Property lists"),
+        RTree => ("H5E_RTREE", "R-Tree spatial index"),
+        RefCountedString => ("H5E_RS", "Reference Counted Strings"),
+        Reference => ("H5E_REFERENCE", "References"),
+        Resource => ("H5E_RESOURCE", "Resource unavailable"),
+        SharedObjectHeaderMessage => ("H5E_SOHM", "Shared Object Header Messages"),
+        SkipList => ("H5E_SLIST", "Skip Lists"),
+        Storage => ("H5E_STORAGE", "Data storage"),
+        SymbolTable => ("H5E_SYM", "Symbol table"),
+        TernarySearchTree => ("H5E_TST", "Ternary Search Trees"),
+        Threadsafety => ("H5E_THREADSAFE", "Threadsafety"),
+        VirtualFileLayer => ("H5E_VFL", "Virtual File Layer"),
+        VirtualObjectLayer => ("H5E_VOL", "Virtual Object Layer"),
+    }
+}
+
+error_codes! {
+    /// The minor error code of an HDF5 error frame.
+    MinorErrorCode, MINOR_CODES;
+
+    variants {
+        /// `H5E_ALIGNMENT`: Alignment error
+        Alignment,
+        /// `H5E_ALREADYEXISTS`: Object already exists
+        AlreadyExists,
+        /// `H5E_ALREADYINIT`: Object already initialized
+        AlreadyInit,
+        /// `H5E_BADFILE`: Bad file ID accessed
+        BadFile,
+        /// `H5E_BADGROUP`: Unable to find ID group information
+        BadGroup,
+        /// `H5E_BADID` (`H5E_BADATOM` in older HDF5): Unable to find ID information (already closed?)
+        BadId,
+        /// `H5E_BADITER`: Iteration failed
+        BadIter,
+        /// `H5E_BADMESG`: Unrecognized message
+        BadMessage,
+        /// `H5E_BADRANGE`: Out of range
+        BadRange,
+        /// `H5E_BADSELECT`: Invalid selection
+        BadSelect,
+        /// `H5E_BADSIZE`: Bad size for object
+        BadSize,
+        /// `H5E_BADTYPE`: Inappropriate type
+        BadType,
+        /// `H5E_BADVALUE`: Bad value
+        BadValue,
+        /// `H5E_CALLBACK`: Callback failed
+        Callback,
+        /// `H5E_CANAPPLY`: Error from filter 'can apply' callback
+        CanApply,
+        /// `H5E_CANTALLOC`: Can't allocate space
+        CantAlloc,
+        /// `H5E_CANTAPPEND`: Can't append object
+        CantAppend,
+        /// `H5E_CANTATTACH`: Can't attach object
+        CantAttach,
+        /// `H5E_CANTCANCEL`: Can't cancel operation
+        CantCancel,
+        /// `H5E_CANTCLEAN`: Unable to mark metadata as clean
+        CantClean,
+        /// `H5E_CANTCLIP`: Can't clip hyperslab region
+        CantClip,
+        /// `H5E_CANTCLOSEFILE`: Unable to close file
+        CantCloseFile,
+        /// `H5E_CANTCLOSEOBJ`: Can't close object
+        CantCloseObj,
+        /// `H5E_CANTCOMPARE`: Can't compare objects
+        CantCompare,
+        /// `H5E_CANTCOMPUTE`: Can't compute value
+        CantCompute,
+        /// `H5E_CANTCONVERT`: Can't convert datatypes
+        CantConvert,
+        /// `H5E_CANTCOPY`: Unable to copy object
+        CantCopy,
+        /// `H5E_CANTCORK`: Unable to cork an object
+        CantCork,
+        /// `H5E_CANTCOUNT`: Can't count elements
+        CantCount,
+        /// `H5E_CANTCREATE`: Unable to create file
+        CantCreate,
+        /// `H5E_CANTDEC`: Unable to decrement reference count
+        CantDec,
+        /// `H5E_CANTDECODE`: Unable to decode value
+        CantDecode,
+        /// `H5E_CANTDELETE`: Can't delete message
+        CantDelete,
+        /// `H5E_CANTDELETEFILE`: Unable to delete file
+        CantDeleteFile,
+        /// `H5E_CANTDEPEND`: Unable to create a flush dependency
+        CantDepend,
+        /// `H5E_CANTDIRTY`: Unable to mark metadata as dirty
+        CantDirty,
+        /// `H5E_CANTENCODE`: Unable to encode value
+        CantEncode,
+        /// `H5E_CANTEXPUNGE`: Unable to expunge a metadata cache entry
+        CantExpunge,
+        /// `H5E_CANTEXTEND`: Can't extend heap's space
+        CantExtend,
+        /// `H5E_CANTFILTER`: Filter operation failed
+        CantFilter,
+        /// `H5E_CANTFIND`: Unable to check for record
+        CantFind,
+        /// `H5E_CANTFLUSH`: Unable to flush data from cache
+        CantFlush,
+        /// `H5E_CANTFREE`: Unable to free object
+        CantFree,
+        /// `H5E_CANTGATHER`: Can't gather data
+        CantGather,
+        /// `H5E_CANTGC`: Unable to garbage collect
+        CantGc,
+        /// `H5E_CANTGET`: Can't get value
+        CantGet,
+        /// `H5E_CANTGETSIZE`: Unable to compute size
+        CantGetSize,
+        /// `H5E_CANTINC`: Unable to increment reference count
+        CantInc,
+        /// `H5E_CANTINIT`: Unable to initialize object
+        CantInit,
+        /// `H5E_CANTINS`: Unable to insert metadata into cache
+        CantIns,
+        /// `H5E_CANTINSERT`: Unable to insert object
+        CantInsert,
+        /// `H5E_CANTLIST`: Unable to list node
+        CantList,
+        /// `H5E_CANTLOAD`: Unable to load metadata into cache
+        CantLoad,
+        /// `H5E_CANTLOCK`: Unable to lock object
+        CantLock,
+        /// `H5E_CANTLOCKFILE`: Unable to lock file
+        CantLockFile,
+        /// `H5E_CANTMARKCLEAN`: Unable to mark a pinned entry as clean
+        CantMarkClean,
+        /// `H5E_CANTMARKDIRTY`: Unable to mark a pinned entry as dirty
+        CantMarkDirty,
+        /// `H5E_CANTMARKSERIALIZED`: Unable to mark an entry as serialized
+        CantMarkSerialized,
+        /// `H5E_CANTMARKUNSERIALIZED`: Unable to mark an entry as unserialized
+        CantMarkUnserialized,
+        /// `H5E_CANTMERGE`: Can't merge objects
+        CantMerge,
+        /// `H5E_CANTMODIFY`: Unable to modify record
+        CantModify,
+        /// `H5E_CANTMOVE`: Can't move object
+        CantMove,
+        /// `H5E_CANTNEXT`: Can't move to next iterator location
+        CantNext,
+        /// `H5E_CANTNOTIFY`: Unable to notify object about action
+        CantNotify,
+        /// `H5E_CANTOPENFILE`: Unable to open file
+        CantOpenFile,
+        /// `H5E_CANTOPENOBJ`: Can't open object
+        CantOpenObj,
+        /// `H5E_CANTOPERATE`: Can't operate on object
+        CantOperate,
+        /// `H5E_CANTPACK`: Can't pack messages
+        CantPack,
+        /// `H5E_CANTPIN`: Unable to pin cache entry
+        CantPin,
+        /// `H5E_CANTPROTECT`: Unable to protect metadata
+        CantProtect,
+        /// `H5E_CANTPUT`: Can't put value
+        CantPut,
+        /// `H5E_CANTRECV`: Can't receive data
+        CantRecv,
+        /// `H5E_CANTREDISTRIBUTE`: Unable to redistribute records
+        CantRedistribute,
+        /// `H5E_CANTREGISTER`: Unable to register new ID
+        CantRegister,
+        /// `H5E_CANTRELEASE`: Unable to release object
+        CantRelease,
+        /// `H5E_CANTREMOVE`: Unable to remove object
+        CantRemove,
+        /// `H5E_CANTRENAME`: Unable to rename object
+        CantRename,
+        /// `H5E_CANTRESET`: Can't reset object
+        CantReset,
+        /// `H5E_CANTRESIZE`: Unable to resize a metadata cache entry
+        CantResize,
+        /// `H5E_CANTRESTORE`: Can't restore condition
+        CantRestore,
+        /// `H5E_CANTREVIVE`: Can't revive object
+        CantRevive,
+        /// `H5E_CANTSELECT`: Can't select hyperslab
+        CantSelect,
+        /// `H5E_CANTSERIALIZE`: Unable to serialize data from cache
+        CantSerialize,
+        /// `H5E_CANTSET`: Can't set value
+        CantSet,
+        /// `H5E_CANTSHRINK`: Can't shrink container
+        CantShrink,
+        /// `H5E_CANTSORT`: Can't sort objects
+        CantSort,
+        /// `H5E_CANTSPLIT`: Unable to split node
+        CantSplit,
+        /// `H5E_CANTSWAP`: Unable to swap records
+        CantSwap,
+        /// `H5E_CANTTAG`: Unable to tag metadata in the cache
+        CantTag,
+        /// `H5E_CANTUNCORK`: Unable to uncork an object
+        CantUncork,
+        /// `H5E_CANTUNDEPEND`: Unable to destroy a flush dependency
+        CantUndepend,
+        /// `H5E_CANTUNLOCK`: Unable to unlock object
+        CantUnlock,
+        /// `H5E_CANTUNLOCKFILE`: Unable to unlock file
+        CantUnlockFile,
+        /// `H5E_CANTUNPIN`: Unable to un-pin cache entry
+        CantUnpin,
+        /// `H5E_CANTUNPROTECT`: Unable to unprotect metadata
+        CantUnprotect,
+        /// `H5E_CANTUNSERIALIZE`: Unable to mark metadata as unserialized
+        CantUnserialize,
+        /// `H5E_CANTUPDATE`: Can't update object
+        CantUpdate,
+        /// `H5E_CANTWAIT`: Can't wait on operation
+        CantWait,
+        /// `H5E_CLOSEERROR`: Close failed
+        CloseError,
+        /// `H5E_COMPLEN`: Name component is too long
+        CompLen,
+        /// `H5E_DUPCLASS`: Duplicate class name in parent class
+        DupClass,
+        /// `H5E_EXISTS`: Object already exists
+        Exists,
+        /// `H5E_FCNTL`: File control (fcntl) failed
+        Fcntl,
+        /// `H5E_FILEEXISTS`: File already exists
+        FileExists,
+        /// `H5E_FILEOPEN`: File already open
+        FileOpen,
+        /// `H5E_INCONSISTENTSTATE`: Internal states are inconsistent
+        InconsistentState,
+        /// `H5E_LINKCOUNT`: Bad object header link count
+        LinkCount,
+        /// `H5E_LOGGING` (`H5E_LOGFAIL` in older HDF5): Failure in the cache logging framework
+        Logging,
+        /// `H5E_MOUNT`: File mount error
+        Mount,
+        /// `H5E_MPI`: Some MPI function failed
+        Mpi,
+        /// `H5E_MPIERRSTR`: MPI Error String
+        MpiErrStr,
+        /// `H5E_NLINKS`: Too many soft links in path
+        NLinks,
+        /// `H5E_NOENCODER`: Filter present but encoding disabled
+        NoEncoder,
+        /// `H5E_NOFILTER`: Requested filter is not available
+        NoFilter,
+        /// `H5E_NOIDS`: Out of IDs for group
+        NoIds,
+        /// `H5E_NO_INDEPENDENT`: Can't perform independent IO
+        NoIndependent,
+        /// `H5E_NOSPACE`: No space available for allocation
+        NoSpace,
+        /// `H5E_NONE_MINOR`: No error
+        NoneMinor,
+        /// `H5E_NOTCACHED`: Metadata not currently cached
+        NotCached,
+        /// `H5E_NOTFOUND`: Object not found
+        NotFound,
+        /// `H5E_NOTHDF5`: Not an HDF5 file
+        NotHdf5,
+        /// `H5E_NOTREGISTERED`: Link class not registered
+        NotRegistered,
+        /// `H5E_OBJOPEN`: Object is already open
+        ObjOpen,
+        /// `H5E_OPENERROR`: Can't open directory or file
+        OpenError,
+        /// `H5E_OVERFLOW`: Address overflowed
+        Overflow,
+        /// `H5E_PATH`: Problem with path to object
+        Path,
+        /// `H5E_PROTECT`: Protected metadata error
+        Protect,
+        /// `H5E_READERROR`: Read failed
+        ReadError,
+        /// `H5E_SEEKERROR`: Seek failed
+        SeekError,
+        /// `H5E_SETDISALLOWED`: Disallowed operation
+        SetDisallowed,
+        /// `H5E_SETLOCAL`: Error from filter 'set local' callback
+        SetLocal,
+        /// `H5E_SYSERRSTR`: System error message
+        SysErrStr,
+        /// `H5E_SYSTEM`: Internal error detected
+        System,
+        /// `H5E_TRAVERSE`: Link traversal failure
+        Traverse,
+        /// `H5E_TRUNCATED`: File has been truncated
+        Truncated,
+        /// `H5E_UNINITIALIZED`: Information is uinitialized
+        Uninitialized,
+        /// `H5E_UNMOUNT`: File unmount error
+        Unmount,
+        /// `H5E_UNSUPPORTED`: Feature is unsupported
+        Unsupported,
+        /// `H5E_VERSION`: Wrong version number
+        Version,
+        /// `H5E_WRITEERROR`: Write failed
+        WriteError,
+    }
+
+    symbols {
+        H5E_ALIGNMENT => Alignment,
+        H5E_ALREADYEXISTS => AlreadyExists,
+        H5E_ALREADYINIT => AlreadyInit,
+        H5E_BADFILE => BadFile,
+        H5E_BADGROUP => BadGroup,
+        [not(feature = "1.14.0")] H5E_BADATOM => BadId,
+        [feature = "1.14.0"] H5E_BADID => BadId,
+        H5E_BADITER => BadIter,
+        H5E_BADMESG => BadMessage,
+        H5E_BADRANGE => BadRange,
+        H5E_BADSELECT => BadSelect,
+        H5E_BADSIZE => BadSize,
+        H5E_BADTYPE => BadType,
+        H5E_BADVALUE => BadValue,
+        H5E_CALLBACK => Callback,
+        H5E_CANAPPLY => CanApply,
+        H5E_CANTALLOC => CantAlloc,
+        [feature = "1.10.0"] H5E_CANTAPPEND => CantAppend,
+        H5E_CANTATTACH => CantAttach,
+        [feature = "1.14.0"] H5E_CANTCANCEL => CantCancel,
+        [feature = "1.10.1"] H5E_CANTCLEAN => CantClean,
+        H5E_CANTCLIP => CantClip,
+        H5E_CANTCLOSEFILE => CantCloseFile,
+        H5E_CANTCLOSEOBJ => CantCloseObj,
+        H5E_CANTCOMPARE => CantCompare,
+        H5E_CANTCOMPUTE => CantCompute,
+        H5E_CANTCONVERT => CantConvert,
+        H5E_CANTCOPY => CantCopy,
+        [feature = "1.10.0"] H5E_CANTCORK => CantCork,
+        H5E_CANTCOUNT => CantCount,
+        H5E_CANTCREATE => CantCreate,
+        H5E_CANTDEC => CantDec,
+        H5E_CANTDECODE => CantDecode,
+        H5E_CANTDELETE => CantDelete,
+        [feature = "1.12.0"] H5E_CANTDELETEFILE => CantDeleteFile,
+        [feature = "1.10.0"] H5E_CANTDEPEND => CantDepend,
+        H5E_CANTDIRTY => CantDirty,
+        H5E_CANTENCODE => CantEncode,
+        H5E_CANTEXPUNGE => CantExpunge,
+        H5E_CANTEXTEND => CantExtend,
+        H5E_CANTFILTER => CantFilter,
+        [feature = "1.14.0"] H5E_CANTFIND => CantFind,
+        H5E_CANTFLUSH => CantFlush,
+        H5E_CANTFREE => CantFree,
+        [feature = "1.10.2"] H5E_CANTGATHER => CantGather,
+        H5E_CANTGC => CantGc,
+        H5E_CANTGET => CantGet,
+        H5E_CANTGETSIZE => CantGetSize,
+        H5E_CANTINC => CantInc,
+        H5E_CANTINIT => CantInit,
+        H5E_CANTINS => CantIns,
+        H5E_CANTINSERT => CantInsert,
+        H5E_CANTLIST => CantList,
+        H5E_CANTLOAD => CantLoad,
+        H5E_CANTLOCK => CantLock,
+        [any(all(feature = "1.10.7", not(feature = "1.12.0")), feature = "1.12.1")] H5E_CANTLOCKFILE => CantLockFile,
+        [feature = "1.10.1"] H5E_CANTMARKCLEAN => CantMarkClean,
+        H5E_CANTMARKDIRTY => CantMarkDirty,
+        [feature = "1.10.1"] H5E_CANTMARKSERIALIZED => CantMarkSerialized,
+        [feature = "1.10.1"] H5E_CANTMARKUNSERIALIZED => CantMarkUnserialized,
+        H5E_CANTMERGE => CantMerge,
+        H5E_CANTMODIFY => CantModify,
+        H5E_CANTMOVE => CantMove,
+        H5E_CANTNEXT => CantNext,
+        [feature = "1.10.0"] H5E_CANTNOTIFY => CantNotify,
+        H5E_CANTOPENFILE => CantOpenFile,
+        H5E_CANTOPENOBJ => CantOpenObj,
+        H5E_CANTOPERATE => CantOperate,
+        H5E_CANTPACK => CantPack,
+        H5E_CANTPIN => CantPin,
+        H5E_CANTPROTECT => CantProtect,
+        [feature = "1.14.0"] H5E_CANTPUT => CantPut,
+        H5E_CANTRECV => CantRecv,
+        H5E_CANTREDISTRIBUTE => CantRedistribute,
+        H5E_CANTREGISTER => CantRegister,
+        H5E_CANTRELEASE => CantRelease,
+        H5E_CANTREMOVE => CantRemove,
+        H5E_CANTRENAME => CantRename,
+        H5E_CANTRESET => CantReset,
+        H5E_CANTRESIZE => CantResize,
+        H5E_CANTRESTORE => CantRestore,
+        H5E_CANTREVIVE => CantRevive,
+        H5E_CANTSELECT => CantSelect,
+        H5E_CANTSERIALIZE => CantSerialize,
+        H5E_CANTSET => CantSet,
+        H5E_CANTSHRINK => CantShrink,
+        H5E_CANTSORT => CantSort,
+        H5E_CANTSPLIT => CantSplit,
+        H5E_CANTSWAP => CantSwap,
+        [feature = "1.10.0"] H5E_CANTTAG => CantTag,
+        [feature = "1.10.0"] H5E_CANTUNCORK => CantUncork,
+        [feature = "1.10.0"] H5E_CANTUNDEPEND => CantUndepend,
+        H5E_CANTUNLOCK => CantUnlock,
+        [any(all(feature = "1.10.7", not(feature = "1.12.0")), feature = "1.12.1")] H5E_CANTUNLOCKFILE => CantUnlockFile,
+        H5E_CANTUNPIN => CantUnpin,
+        H5E_CANTUNPROTECT => CantUnprotect,
+        [feature = "1.10.1"] H5E_CANTUNSERIALIZE => CantUnserialize,
+        H5E_CANTUPDATE => CantUpdate,
+        [feature = "1.14.0"] H5E_CANTWAIT => CantWait,
+        H5E_CLOSEERROR => CloseError,
+        H5E_COMPLEN => CompLen,
+        H5E_DUPCLASS => DupClass,
+        H5E_EXISTS => Exists,
+        H5E_FCNTL => Fcntl,
+        H5E_FILEEXISTS => FileExists,
+        H5E_FILEOPEN => FileOpen,
+        [feature = "1.10.7"] H5E_INCONSISTENTSTATE => InconsistentState,
+        H5E_LINKCOUNT => LinkCount,
+        [all(feature = "1.10.0", not(feature = "1.12.0"))] H5E_LOGFAIL => Logging,
+        [feature = "1.10.5"] H5E_LOGGING => Logging,
+        H5E_MOUNT => Mount,
+        H5E_MPI => Mpi,
+        H5E_MPIERRSTR => MpiErrStr,
+        H5E_NLINKS => NLinks,
+        H5E_NOENCODER => NoEncoder,
+        H5E_NOFILTER => NoFilter,
+        H5E_NOIDS => NoIds,
+        [feature = "1.10.2"] H5E_NO_INDEPENDENT => NoIndependent,
+        H5E_NOSPACE => NoSpace,
+        H5E_NONE_MINOR => NoneMinor,
+        H5E_NOTCACHED => NotCached,
+        H5E_NOTFOUND => NotFound,
+        H5E_NOTHDF5 => NotHdf5,
+        H5E_NOTREGISTERED => NotRegistered,
+        H5E_OBJOPEN => ObjOpen,
+        [feature = "1.8.11"] H5E_OPENERROR => OpenError,
+        H5E_OVERFLOW => Overflow,
+        H5E_PATH => Path,
+        H5E_PROTECT => Protect,
+        H5E_READERROR => ReadError,
+        H5E_SEEKERROR => SeekError,
+        [feature = "1.8.9"] H5E_SETDISALLOWED => SetDisallowed,
+        H5E_SETLOCAL => SetLocal,
+        H5E_SYSERRSTR => SysErrStr,
+        H5E_SYSTEM => System,
+        H5E_TRAVERSE => Traverse,
+        H5E_TRUNCATED => Truncated,
+        H5E_UNINITIALIZED => Uninitialized,
+        [feature = "1.14.0"] H5E_UNMOUNT => Unmount,
+        H5E_UNSUPPORTED => Unsupported,
+        H5E_VERSION => Version,
+        H5E_WRITEERROR => WriteError,
+    }
+
+    meta {
+        Alignment => ("H5E_ALIGNMENT", "Alignment error"),
+        AlreadyExists => ("H5E_ALREADYEXISTS", "Object already exists"),
+        AlreadyInit => ("H5E_ALREADYINIT", "Object already initialized"),
+        BadFile => ("H5E_BADFILE", "Bad file ID accessed"),
+        BadGroup => ("H5E_BADGROUP", "Unable to find ID group information"),
+        [feature = "1.14.0"] BadId => ("H5E_BADID", "Unable to find ID information (already closed?)"),
+        [not(feature = "1.14.0")] BadId => ("H5E_BADATOM", "Unable to find atom information (already closed?)"),
+        BadIter => ("H5E_BADITER", "Iteration failed"),
+        BadMessage => ("H5E_BADMESG", "Unrecognized message"),
+        BadRange => ("H5E_BADRANGE", "Out of range"),
+        BadSelect => ("H5E_BADSELECT", "Invalid selection"),
+        BadSize => ("H5E_BADSIZE", "Bad size for object"),
+        BadType => ("H5E_BADTYPE", "Inappropriate type"),
+        BadValue => ("H5E_BADVALUE", "Bad value"),
+        Callback => ("H5E_CALLBACK", "Callback failed"),
+        CanApply => ("H5E_CANAPPLY", "Error from filter 'can apply' callback"),
+        CantAlloc => ("H5E_CANTALLOC", "Can't allocate space"),
+        CantAppend => ("H5E_CANTAPPEND", "Can't append object"),
+        CantAttach => ("H5E_CANTATTACH", "Can't attach object"),
+        CantCancel => ("H5E_CANTCANCEL", "Can't cancel operation"),
+        CantClean => ("H5E_CANTCLEAN", "Unable to mark metadata as clean"),
+        CantClip => ("H5E_CANTCLIP", "Can't clip hyperslab region"),
+        CantCloseFile => ("H5E_CANTCLOSEFILE", "Unable to close file"),
+        CantCloseObj => ("H5E_CANTCLOSEOBJ", "Can't close object"),
+        CantCompare => ("H5E_CANTCOMPARE", "Can't compare objects"),
+        CantCompute => ("H5E_CANTCOMPUTE", "Can't compute value"),
+        CantConvert => ("H5E_CANTCONVERT", "Can't convert datatypes"),
+        CantCopy => ("H5E_CANTCOPY", "Unable to copy object"),
+        CantCork => ("H5E_CANTCORK", "Unable to cork an object"),
+        CantCount => ("H5E_CANTCOUNT", "Can't count elements"),
+        CantCreate => ("H5E_CANTCREATE", "Unable to create file"),
+        CantDec => ("H5E_CANTDEC", "Unable to decrement reference count"),
+        CantDecode => ("H5E_CANTDECODE", "Unable to decode value"),
+        CantDelete => ("H5E_CANTDELETE", "Can't delete message"),
+        CantDeleteFile => ("H5E_CANTDELETEFILE", "Unable to delete file"),
+        CantDepend => ("H5E_CANTDEPEND", "Unable to create a flush dependency"),
+        CantDirty => ("H5E_CANTDIRTY", "Unable to mark metadata as dirty"),
+        CantEncode => ("H5E_CANTENCODE", "Unable to encode value"),
+        CantExpunge => ("H5E_CANTEXPUNGE", "Unable to expunge a metadata cache entry"),
+        CantExtend => ("H5E_CANTEXTEND", "Can't extend heap's space"),
+        CantFilter => ("H5E_CANTFILTER", "Filter operation failed"),
+        CantFind => ("H5E_CANTFIND", "Unable to check for record"),
+        CantFlush => ("H5E_CANTFLUSH", "Unable to flush data from cache"),
+        CantFree => ("H5E_CANTFREE", "Unable to free object"),
+        CantGather => ("H5E_CANTGATHER", "Can't gather data"),
+        CantGc => ("H5E_CANTGC", "Unable to garbage collect"),
+        CantGet => ("H5E_CANTGET", "Can't get value"),
+        CantGetSize => ("H5E_CANTGETSIZE", "Unable to compute size"),
+        CantInc => ("H5E_CANTINC", "Unable to increment reference count"),
+        CantInit => ("H5E_CANTINIT", "Unable to initialize object"),
+        CantIns => ("H5E_CANTINS", "Unable to insert metadata into cache"),
+        CantInsert => ("H5E_CANTINSERT", "Unable to insert object"),
+        CantList => ("H5E_CANTLIST", "Unable to list node"),
+        CantLoad => ("H5E_CANTLOAD", "Unable to load metadata into cache"),
+        CantLock => ("H5E_CANTLOCK", "Unable to lock object"),
+        CantLockFile => ("H5E_CANTLOCKFILE", "Unable to lock file"),
+        CantMarkClean => ("H5E_CANTMARKCLEAN", "Unable to mark a pinned entry as clean"),
+        CantMarkDirty => ("H5E_CANTMARKDIRTY", "Unable to mark a pinned entry as dirty"),
+        CantMarkSerialized => ("H5E_CANTMARKSERIALIZED", "Unable to mark an entry as serialized"),
+        CantMarkUnserialized => ("H5E_CANTMARKUNSERIALIZED", "Unable to mark an entry as unserialized"),
+        CantMerge => ("H5E_CANTMERGE", "Can't merge objects"),
+        CantModify => ("H5E_CANTMODIFY", "Unable to modify record"),
+        CantMove => ("H5E_CANTMOVE", "Can't move object"),
+        CantNext => ("H5E_CANTNEXT", "Can't move to next iterator location"),
+        CantNotify => ("H5E_CANTNOTIFY", "Unable to notify object about action"),
+        CantOpenFile => ("H5E_CANTOPENFILE", "Unable to open file"),
+        CantOpenObj => ("H5E_CANTOPENOBJ", "Can't open object"),
+        CantOperate => ("H5E_CANTOPERATE", "Can't operate on object"),
+        CantPack => ("H5E_CANTPACK", "Can't pack messages"),
+        CantPin => ("H5E_CANTPIN", "Unable to pin cache entry"),
+        CantProtect => ("H5E_CANTPROTECT", "Unable to protect metadata"),
+        CantPut => ("H5E_CANTPUT", "Can't put value"),
+        CantRecv => ("H5E_CANTRECV", "Can't receive data"),
+        CantRedistribute => ("H5E_CANTREDISTRIBUTE", "Unable to redistribute records"),
+        CantRegister => ("H5E_CANTREGISTER", "Unable to register new ID"),
+        CantRelease => ("H5E_CANTRELEASE", "Unable to release object"),
+        CantRemove => ("H5E_CANTREMOVE", "Unable to remove object"),
+        CantRename => ("H5E_CANTRENAME", "Unable to rename object"),
+        CantReset => ("H5E_CANTRESET", "Can't reset object"),
+        CantResize => ("H5E_CANTRESIZE", "Unable to resize a metadata cache entry"),
+        CantRestore => ("H5E_CANTRESTORE", "Can't restore condition"),
+        CantRevive => ("H5E_CANTREVIVE", "Can't revive object"),
+        CantSelect => ("H5E_CANTSELECT", "Can't select hyperslab"),
+        CantSerialize => ("H5E_CANTSERIALIZE", "Unable to serialize data from cache"),
+        CantSet => ("H5E_CANTSET", "Can't set value"),
+        CantShrink => ("H5E_CANTSHRINK", "Can't shrink container"),
+        CantSort => ("H5E_CANTSORT", "Can't sort objects"),
+        CantSplit => ("H5E_CANTSPLIT", "Unable to split node"),
+        CantSwap => ("H5E_CANTSWAP", "Unable to swap records"),
+        CantTag => ("H5E_CANTTAG", "Unable to tag metadata in the cache"),
+        CantUncork => ("H5E_CANTUNCORK", "Unable to uncork an object"),
+        CantUndepend => ("H5E_CANTUNDEPEND", "Unable to destroy a flush dependency"),
+        CantUnlock => ("H5E_CANTUNLOCK", "Unable to unlock object"),
+        CantUnlockFile => ("H5E_CANTUNLOCKFILE", "Unable to unlock file"),
+        CantUnpin => ("H5E_CANTUNPIN", "Unable to un-pin cache entry"),
+        CantUnprotect => ("H5E_CANTUNPROTECT", "Unable to unprotect metadata"),
+        CantUnserialize => ("H5E_CANTUNSERIALIZE", "Unable to mark metadata as unserialized"),
+        CantUpdate => ("H5E_CANTUPDATE", "Can't update object"),
+        CantWait => ("H5E_CANTWAIT", "Can't wait on operation"),
+        CloseError => ("H5E_CLOSEERROR", "Close failed"),
+        CompLen => ("H5E_COMPLEN", "Name component is too long"),
+        DupClass => ("H5E_DUPCLASS", "Duplicate class name in parent class"),
+        Exists => ("H5E_EXISTS", "Object already exists"),
+        Fcntl => ("H5E_FCNTL", "File control (fcntl) failed"),
+        FileExists => ("H5E_FILEEXISTS", "File already exists"),
+        FileOpen => ("H5E_FILEOPEN", "File already open"),
+        InconsistentState => ("H5E_INCONSISTENTSTATE", "Internal states are inconsistent"),
+        LinkCount => ("H5E_LINKCOUNT", "Bad object header link count"),
+        [all(feature = "1.10.0", not(feature = "1.10.5"))] Logging => ("H5E_LOGFAIL", "Failure in the cache logging framework"),
+        [not(all(feature = "1.10.0", not(feature = "1.10.5")))] Logging => ("H5E_LOGGING", "Failure in the cache logging framework"),
+        Mount => ("H5E_MOUNT", "File mount error"),
+        Mpi => ("H5E_MPI", "Some MPI function failed"),
+        MpiErrStr => ("H5E_MPIERRSTR", "MPI Error String"),
+        NLinks => ("H5E_NLINKS", "Too many soft links in path"),
+        NoEncoder => ("H5E_NOENCODER", "Filter present but encoding disabled"),
+        NoFilter => ("H5E_NOFILTER", "Requested filter is not available"),
+        NoIds => ("H5E_NOIDS", "Out of IDs for group"),
+        NoIndependent => ("H5E_NO_INDEPENDENT", "Can't perform independent IO"),
+        NoSpace => ("H5E_NOSPACE", "No space available for allocation"),
+        NoneMinor => ("H5E_NONE_MINOR", "No error"),
+        NotCached => ("H5E_NOTCACHED", "Metadata not currently cached"),
+        NotFound => ("H5E_NOTFOUND", "Object not found"),
+        NotHdf5 => ("H5E_NOTHDF5", "Not an HDF5 file"),
+        NotRegistered => ("H5E_NOTREGISTERED", "Link class not registered"),
+        ObjOpen => ("H5E_OBJOPEN", "Object is already open"),
+        OpenError => ("H5E_OPENERROR", "Can't open directory or file"),
+        Overflow => ("H5E_OVERFLOW", "Address overflowed"),
+        Path => ("H5E_PATH", "Problem with path to object"),
+        Protect => ("H5E_PROTECT", "Protected metadata error"),
+        ReadError => ("H5E_READERROR", "Read failed"),
+        SeekError => ("H5E_SEEKERROR", "Seek failed"),
+        SetDisallowed => ("H5E_SETDISALLOWED", "Disallowed operation"),
+        SetLocal => ("H5E_SETLOCAL", "Error from filter 'set local' callback"),
+        SysErrStr => ("H5E_SYSERRSTR", "System error message"),
+        System => ("H5E_SYSTEM", "Internal error detected"),
+        Traverse => ("H5E_TRAVERSE", "Link traversal failure"),
+        Truncated => ("H5E_TRUNCATED", "File has been truncated"),
+        Uninitialized => ("H5E_UNINITIALIZED", "Information is uinitialized"),
+        Unmount => ("H5E_UNMOUNT", "File unmount error"),
+        Unsupported => ("H5E_UNSUPPORTED", "Feature is unsupported"),
+        Version => ("H5E_VERSION", "Wrong version number"),
+        WriteError => ("H5E_WRITEERROR", "Write failed"),
+    }
+}

--- a/hdf5/src/globals.rs
+++ b/hdf5/src/globals.rs
@@ -188,6 +188,7 @@ link_hid!(H5E_STORAGE, h5e::H5E_STORAGE);
 link_hid!(H5E_FILE, h5e::H5E_FILE);
 link_hid!(H5E_SOHM, h5e::H5E_SOHM);
 link_hid!(H5E_SYM, h5e::H5E_SYM);
+#[cfg(feature = "1.8.11")]
 link_hid!(H5E_PLUGIN, h5e::H5E_PLUGIN);
 link_hid!(H5E_VFL, h5e::H5E_VFL);
 link_hid!(H5E_INTERNAL, h5e::H5E_INTERNAL);
@@ -242,6 +243,7 @@ link_hid!(H5E_CANTRELEASE, h5e::H5E_CANTRELEASE);
 link_hid!(H5E_CANTGET, h5e::H5E_CANTGET);
 link_hid!(H5E_CANTSET, h5e::H5E_CANTSET);
 link_hid!(H5E_DUPCLASS, h5e::H5E_DUPCLASS);
+#[cfg(feature = "1.8.9")]
 link_hid!(H5E_SETDISALLOWED, h5e::H5E_SETDISALLOWED);
 link_hid!(H5E_CANTMERGE, h5e::H5E_CANTMERGE);
 link_hid!(H5E_CANTREVIVE, h5e::H5E_CANTREVIVE);
@@ -267,6 +269,7 @@ link_hid!(H5E_CANTCLOSEOBJ, h5e::H5E_CANTCLOSEOBJ);
 link_hid!(H5E_COMPLEN, h5e::H5E_COMPLEN);
 link_hid!(H5E_PATH, h5e::H5E_PATH);
 link_hid!(H5E_NONE_MINOR, h5e::H5E_NONE_MINOR);
+#[cfg(feature = "1.8.11")]
 link_hid!(H5E_OPENERROR, h5e::H5E_OPENERROR);
 link_hid!(H5E_FILEEXISTS, h5e::H5E_FILEEXISTS);
 link_hid!(H5E_FILEOPEN, h5e::H5E_FILEOPEN);
@@ -331,6 +334,80 @@ link_hid!(H5E_CANTMODIFY, h5e::H5E_CANTMODIFY);
 link_hid!(H5E_CANTREMOVE, h5e::H5E_CANTREMOVE);
 link_hid!(H5E_CANTCONVERT, h5e::H5E_CANTCONVERT);
 link_hid!(H5E_BADSIZE, h5e::H5E_BADSIZE);
+#[cfg(any(all(feature = "1.10.7", not(feature = "1.12.0")), feature = "1.12.1"))]
+link_hid!(H5E_CANTLOCKFILE, h5e::H5E_CANTLOCKFILE);
+#[cfg(any(all(feature = "1.10.7", not(feature = "1.12.0")), feature = "1.12.1"))]
+link_hid!(H5E_CANTUNLOCKFILE, h5e::H5E_CANTUNLOCKFILE);
+#[cfg(feature = "1.12.1")]
+link_hid!(H5E_LIB, h5e::H5E_LIB);
+#[cfg(feature = "1.14.0")]
+link_hid!(H5E_BADID, h5e::H5E_BADID);
+#[cfg(feature = "1.14.0")]
+link_hid!(H5E_CANTCANCEL, h5e::H5E_CANTCANCEL);
+#[cfg(feature = "1.14.0")]
+link_hid!(H5E_CANTFIND, h5e::H5E_CANTFIND);
+#[cfg(feature = "1.14.0")]
+link_hid!(H5E_CANTPUT, h5e::H5E_CANTPUT);
+#[cfg(feature = "1.14.0")]
+link_hid!(H5E_CANTWAIT, h5e::H5E_CANTWAIT);
+#[cfg(feature = "1.14.0")]
+link_hid!(H5E_EVENTSET, h5e::H5E_EVENTSET);
+#[cfg(feature = "1.14.0")]
+link_hid!(H5E_ID, h5e::H5E_ID);
+#[cfg(feature = "1.14.0")]
+link_hid!(H5E_UNMOUNT, h5e::H5E_UNMOUNT);
+#[cfg(feature = "2.0.0")]
+link_hid!(H5E_RTREE, h5e::H5E_RTREE);
+#[cfg(feature = "2.0.0")]
+link_hid!(H5E_THREADSAFE, h5e::H5E_THREADSAFE);
+#[cfg(feature = "1.10.0")]
+link_hid!(H5E_EARRAY, h5e::H5E_EARRAY);
+#[cfg(feature = "1.10.0")]
+link_hid!(H5E_FARRAY, h5e::H5E_FARRAY);
+#[cfg(feature = "1.10.1")]
+link_hid!(H5E_PAGEBUF, h5e::H5E_PAGEBUF);
+#[cfg(feature = "1.10.3")]
+link_hid!(H5E_CONTEXT, h5e::H5E_CONTEXT);
+#[cfg(feature = "1.12.0")]
+link_hid!(H5E_MAP, h5e::H5E_MAP);
+#[cfg(feature = "1.12.0")]
+link_hid!(H5E_VOL, h5e::H5E_VOL);
+#[cfg(feature = "1.10.0")]
+link_hid!(H5E_CANTAPPEND, h5e::H5E_CANTAPPEND);
+#[cfg(feature = "1.10.0")]
+link_hid!(H5E_CANTCORK, h5e::H5E_CANTCORK);
+#[cfg(feature = "1.10.0")]
+link_hid!(H5E_CANTDEPEND, h5e::H5E_CANTDEPEND);
+#[cfg(feature = "1.10.0")]
+link_hid!(H5E_CANTNOTIFY, h5e::H5E_CANTNOTIFY);
+#[cfg(feature = "1.10.0")]
+link_hid!(H5E_CANTTAG, h5e::H5E_CANTTAG);
+#[cfg(feature = "1.10.0")]
+link_hid!(H5E_CANTUNCORK, h5e::H5E_CANTUNCORK);
+#[cfg(feature = "1.10.0")]
+link_hid!(H5E_CANTUNDEPEND, h5e::H5E_CANTUNDEPEND);
+#[cfg(all(feature = "1.10.0", not(feature = "1.12.0")))]
+link_hid!(H5E_LOGFAIL, h5e::H5E_LOGFAIL);
+#[cfg(feature = "1.10.1")]
+link_hid!(H5E_CANTCLEAN, h5e::H5E_CANTCLEAN);
+#[cfg(feature = "1.10.1")]
+link_hid!(H5E_CANTMARKCLEAN, h5e::H5E_CANTMARKCLEAN);
+#[cfg(feature = "1.10.1")]
+link_hid!(H5E_CANTMARKSERIALIZED, h5e::H5E_CANTMARKSERIALIZED);
+#[cfg(feature = "1.10.1")]
+link_hid!(H5E_CANTMARKUNSERIALIZED, h5e::H5E_CANTMARKUNSERIALIZED);
+#[cfg(feature = "1.10.1")]
+link_hid!(H5E_CANTUNSERIALIZE, h5e::H5E_CANTUNSERIALIZE);
+#[cfg(feature = "1.12.0")]
+link_hid!(H5E_CANTDELETEFILE, h5e::H5E_CANTDELETEFILE);
+#[cfg(feature = "1.10.2")]
+link_hid!(H5E_CANTGATHER, h5e::H5E_CANTGATHER);
+#[cfg(feature = "1.10.7")]
+link_hid!(H5E_INCONSISTENTSTATE, h5e::H5E_INCONSISTENTSTATE);
+#[cfg(feature = "1.10.5")]
+link_hid!(H5E_LOGGING, h5e::H5E_LOGGING);
+#[cfg(feature = "1.10.2")]
+link_hid!(H5E_NO_INDEPENDENT, h5e::H5E_NO_INDEPENDENT);
 
 // H5R constants
 pub static H5R_OBJ_REF_BUF_SIZE: LazyLock<usize> = LazyLock::new(|| mem::size_of::<haddr_t>());

--- a/hdf5/src/hl/container.rs
+++ b/hdf5/src/hl/container.rs
@@ -683,3 +683,129 @@ impl Container {
         self.as_writer().write_scalar(val)
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use ndarray::{arr1, arr2, s};
+
+    use crate::internal_prelude::*;
+
+    /// Every failure below is caught in Rust before HDF5 is called, so none of them carries an
+    /// HDF5 error stack. If a check is dropped, HDF5 fails later and this catches it.
+    #[track_caller]
+    fn assert_is_internal(err: &Error) {
+        assert!(err.stack().is_none(), "expected a Rust-side error, got an HDF5 stack: {err:?}");
+    }
+
+    /// Reading with the wrong dimensionality.
+    #[test]
+    pub fn test_read_ndim_mismatch() {
+        with_tmp_file(|file| {
+            let ds = file.new_dataset::<i32>().shape([4, 3]).create("d").unwrap();
+            ds.write(&arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])).unwrap();
+
+            let err = ds.read_1d::<i32>().unwrap_err();
+            assert_eq!(err.to_string(), "ndim mismatch: expected 1, got 2");
+            assert_is_internal(&err);
+
+            // the same container logic backs attributes
+            let attr = ds.new_attr::<i32>().shape([2, 2]).create("a").unwrap();
+            let err = attr.read_1d::<i32>().unwrap_err();
+            assert_eq!(err.to_string(), "ndim mismatch: expected 1, got 2");
+            assert_is_internal(&err);
+
+            // matching read
+            assert_eq!(ds.read_2d::<i32>().unwrap().dim(), (4, 3));
+        })
+    }
+
+    /// Reading a non-scalar as a scalar, and writing a scalar to a non-scalar.
+    #[test]
+    pub fn test_scalar_ndim_mismatch() {
+        with_tmp_file(|file| {
+            let ds = file.new_dataset::<i32>().shape([4, 3]).create("d").unwrap();
+            let err = ds.read_scalar::<i32>().unwrap_err();
+            assert_eq!(err.to_string(), "ndim mismatch: expected scalar, got 2");
+            assert_is_internal(&err);
+
+            let err = ds.write_scalar(&1i32).unwrap_err();
+            assert_eq!(err.to_string(), "ndim mismatch: expected scalar, got 2");
+            assert_is_internal(&err);
+
+            let scalar = file.new_dataset::<i32>().shape(()).create("s").unwrap();
+            scalar.write_scalar(&42i32).unwrap();
+            assert_eq!(scalar.read_scalar::<i32>().unwrap(), 42);
+        })
+    }
+
+    /// Writing an array whose shape does not match the destination.
+    #[test]
+    pub fn test_write_shape_mismatch() {
+        with_tmp_file(|file| {
+            let ds = file.new_dataset::<i32>().shape([4, 3]).create("d").unwrap();
+            let err = ds.write(&arr1(&[1i32, 2, 3])).unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "shape mismatch when writing: memory = [3], destination = [4, 3]"
+            );
+            assert_is_internal(&err);
+
+            // correctly shaped write
+            ds.write(&arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])).unwrap();
+        })
+    }
+
+    /// Selecting outside the extents of the container.
+    #[test]
+    pub fn test_selection_out_of_bounds() {
+        with_tmp_file(|file| {
+            let ds = file.new_dataset::<i32>().shape([4, 3]).create("d").unwrap();
+            let err = ds.read_slice_1d::<i32, _>(s![99, ..]).unwrap_err();
+            assert_eq!(err.to_string(), "Index 99 out of bounds for axis 0 with size 4");
+            assert_is_internal(&err);
+
+            let err = ds.write_slice(&arr1(&[1i32, 2, 3]), s![99, ..]).unwrap_err();
+            assert_eq!(err.to_string(), "Index 99 out of bounds for axis 0 with size 4");
+            assert_is_internal(&err);
+
+            // in-bounds selection
+            assert_eq!(ds.read_slice_1d::<i32, _>(s![3, ..]).unwrap().len(), 3);
+        })
+    }
+
+    /// Reading as a type with no conversion path from the stored type.
+    #[test]
+    pub fn test_no_conversion_path() {
+        with_tmp_file(|file| {
+            let ds =
+                file.new_dataset::<hdf5_types::FixedAscii<8>>().shape([2]).create("s").unwrap();
+            let err = ds.read_1d::<i32>().unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "no conversion paths found from '<HDF5 datatype: string (len 8)>' to '<HDF5 datatype: int32>'"
+            );
+            assert_is_internal(&err);
+        })
+    }
+
+    /// Demanding a stricter conversion than the types allow.
+    #[test]
+    pub fn test_conversion_level_too_strict() {
+        with_tmp_file(|file| {
+            let ds = file.new_dataset::<i32>().shape([2]).create("d").unwrap();
+            ds.write(&arr1(&[1i32, 2])).unwrap();
+
+            // i32 -> i64 is a hard conversion, so demanding no-op must fail
+            let err = ds.as_reader().no_convert().read_1d::<i64>().unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "Cannot convert from int32 to int64, required conversion no-op; available: hard"
+            );
+            assert_is_internal(&err);
+
+            // the default (soft) allows it, and no-op is fine for the exact type
+            assert_eq!(ds.read_1d::<i64>().unwrap(), arr1(&[1i64, 2]));
+            assert_eq!(ds.as_reader().no_convert().read_1d::<i32>().unwrap(), arr1(&[1i32, 2]));
+        })
+    }
+}

--- a/hdf5/src/hl/file.rs
+++ b/hdf5/src/hl/file.rs
@@ -401,8 +401,9 @@ pub mod tests {
                     Err::<(), _>(err.clone()),
                     "unable to (?:synchronously )?create file"
                 );
+                // The minor code varies by HDF5 version (CantCreate vs FileExists)
+                // The stable part is that it's a File error and not a corrupt-superblock read.
                 assert!(err.contains_major(MajorErrorCode::File), "{err:?}");
-                assert!(err.contains_minor(MinorErrorCode::CantCreate), "{err:?}");
                 assert!(!err.contains_minor(MinorErrorCode::NotHdf5), "{err:?}");
             }
         });
@@ -433,10 +434,12 @@ pub mod tests {
             File::create_excl(&path).unwrap();
             let err = File::create_excl(&path).unwrap_err();
             assert_err_re!(Err::<(), _>(err.clone()), "unable to (?:synchronously )?create file");
-            // H5Fcreate does not report H5E_FILEEXISTS for an existing file. EEXIST is only
-            // visible as errno text on the innermost frame.
-            assert!(err.contains_minor(MinorErrorCode::CantCreate), "{err:?}");
-            assert!(!err.contains_minor(MinorErrorCode::FileExists), "{err:?}");
+            // Older HDF5 reports FileExists for an existing file, newer reports CantCreate.
+            assert!(
+                err.contains_minor(MinorErrorCode::CantCreate)
+                    || err.contains_minor(MinorErrorCode::FileExists),
+                "{err:?}"
+            );
         });
     }
 

--- a/hdf5/src/hl/file.rs
+++ b/hdf5/src/hl/file.rs
@@ -434,12 +434,10 @@ pub mod tests {
             File::create_excl(&path).unwrap();
             let err = File::create_excl(&path).unwrap_err();
             assert_err_re!(Err::<(), _>(err.clone()), "unable to (?:synchronously )?create file");
-            // Older HDF5 reports FileExists for an existing file, newer reports CantCreate.
-            assert!(
-                err.contains_minor(MinorErrorCode::CantCreate)
-                    || err.contains_minor(MinorErrorCode::FileExists),
-                "{err:?}"
-            );
+            // The specific minor code varies by HDF5 version and build, assert on what's stable
+            let minors: Vec<_> = err.stack().unwrap().minor_codes().collect();
+            assert!(err.contains_major(MajorErrorCode::File), "minors={minors:?}: {err}");
+            assert!(!err.contains_minor(MinorErrorCode::NotHdf5), "minors={minors:?}: {err}");
         });
     }
 

--- a/hdf5/src/hl/file.rs
+++ b/hdf5/src/hl/file.rs
@@ -380,16 +380,39 @@ pub mod tests {
     #[test]
     pub fn test_unable_to_open() {
         with_tmp_dir(|dir| {
-            assert_err_re!(File::open(&dir), "unable to (?:synchronously )?open file");
-            assert_err_re!(File::open_rw(&dir), "unable to (?:synchronously )?open file");
-            assert_err_re!(File::create_excl(&dir), "unable to (?:synchronously )?create file");
-            assert_err_re!(File::create(&dir), "unable to (?:synchronously )?create file");
-            assert_err_re!(File::append(&dir), "unable to (?:synchronously )?create file");
+            // Opening a directory fails, but how it fails is not portable: read-only succeeds
+            // at the OS level on unix, so HDF5 gets as far as the superblock and reports
+            // NotHdf5, while read-write fails with EISDIR first. Only the shared codes are
+            // asserted here. The message text gained "synchronously" in HDF5 1.14, the codes
+            // did not move.
+            for err in [File::open(&dir).unwrap_err(), File::open_rw(&dir).unwrap_err()] {
+                assert_err_re!(Err::<(), _>(err.clone()), "unable to (?:synchronously )?open file");
+                assert!(err.contains_major(MajorErrorCode::File), "{err:?}");
+                assert!(err.contains_minor(MinorErrorCode::CantOpenFile), "{err:?}");
+            }
+            // Creating over a directory cannot report the underlying EISDIR/EEXIST as a code;
+            // HDF5 only ever says CantCreate here, with errno buried in the message text.
+            for err in [
+                File::create_excl(&dir).unwrap_err(),
+                File::create(&dir).unwrap_err(),
+                File::append(&dir).unwrap_err(),
+            ] {
+                assert_err_re!(
+                    Err::<(), _>(err.clone()),
+                    "unable to (?:synchronously )?create file"
+                );
+                assert!(err.contains_major(MajorErrorCode::File), "{err:?}");
+                assert!(err.contains_minor(MinorErrorCode::CantCreate), "{err:?}");
+                assert!(!err.contains_minor(MinorErrorCode::NotHdf5), "{err:?}");
+            }
         });
         with_tmp_path(|path| {
             fs::File::create(&path).unwrap().write_all(b"foo").unwrap();
             assert!(fs::metadata(&path).is_ok());
-            assert_err_re!(File::open(&path), "unable to (?:synchronously )?open file");
+            let err = File::open(&path).unwrap_err();
+            assert_err_re!(Err::<(), _>(err.clone()), "unable to (?:synchronously )?open file");
+            // The file exists but has no valid superblock
+            assert!(err.contains_minor(MinorErrorCode::NotHdf5), "{err:?}");
         })
     }
 
@@ -408,7 +431,12 @@ pub mod tests {
     pub fn test_file_create_excl() {
         with_tmp_path(|path| {
             File::create_excl(&path).unwrap();
-            assert_err_re!(File::create_excl(&path), "unable to (?:synchronously )?create file");
+            let err = File::create_excl(&path).unwrap_err();
+            assert_err_re!(Err::<(), _>(err.clone()), "unable to (?:synchronously )?create file");
+            // H5Fcreate does not report H5E_FILEEXISTS for an existing file. EEXIST is only
+            // visible as errno text on the innermost frame.
+            assert!(err.contains_minor(MinorErrorCode::CantCreate), "{err:?}");
+            assert!(!err.contains_minor(MinorErrorCode::FileExists), "{err:?}");
         });
     }
 

--- a/hdf5/src/hl/group.rs
+++ b/hdf5/src/hl/group.rs
@@ -882,6 +882,22 @@ pub mod tests {
     }
 
     #[test]
+    pub fn test_missing_group_error_codes() {
+        with_tmp_file(|file| {
+            file.create_group("a").unwrap();
+            // Both a missing intermediate and a missing leaf report the same codes, so callers
+            // can detect "no such object" without matching on the message text.
+            for path in ["/foo/baz", "/a/baz"] {
+                let err = file.group(path).unwrap_err();
+                assert!(err.contains_major(MajorErrorCode::SymbolTable), "{path}: {err:?}");
+                assert!(err.contains_minor(MinorErrorCode::NotFound), "{path}: {err:?}");
+                assert!(!err.contains_minor(MinorErrorCode::NotHdf5), "{path}: {err:?}");
+            }
+            file.group("a").unwrap();
+        })
+    }
+
+    #[test]
     pub fn test_unlink() {
         with_tmp_file(|file| {
             file.create_group("/foo/bar").unwrap();

--- a/hdf5/src/lib.rs
+++ b/hdf5/src/lib.rs
@@ -56,6 +56,7 @@ mod export {
         class::from_id,
         dim::{Dimension, Ix},
         error::{Error, ErrorFrame, ErrorStack, ExpandedErrorStack, Result, silence_errors},
+        error_codes::{MajorErrorCode, MinorErrorCode},
         hl::extents::{Extent, Extents, SimpleExtents},
         hl::selection::{Hyperslab, Selection, SliceOrIndex},
         hl::{
@@ -157,6 +158,7 @@ mod class;
 
 mod dim;
 mod error;
+mod error_codes;
 #[doc(hidden)]
 pub mod globals;
 mod handle;

--- a/hdf5/tests/test_dataset.rs
+++ b/hdf5/tests/test_dataset.rs
@@ -379,7 +379,14 @@ fn test_read_enum_rejects_missing_destination_variants() -> hdf5::Result<()> {
             values.as_slice().unwrap(),
             actual.as_slice().unwrap(),
         ),
-        Err(_) => Ok(()),
+        // Naming the members keeps this from passing on an unrelated failure.
+        Err(err) => {
+            assert_eq!(
+                err.to_string(),
+                "Cannot convert enum at datatype: destination is missing source members: D, E"
+            );
+            Ok(())
+        }
     }
 }
 
@@ -655,4 +662,32 @@ fn remove_attr() {
     assert!(ds.attr("bar").is_ok());
     ds.delete_attr("bar").unwrap();
     assert!(ds.attr("bar").is_err());
+}
+
+#[test]
+fn test_resize_non_resizable_dataset() {
+    let file = new_in_memory_file().unwrap();
+    // A dataset with contiguous storage has no maxshape and cannot be resized
+    let ds = file.new_dataset::<i32>().shape([4]).create("fixed").unwrap();
+    let err = ds.resize([8]).unwrap_err();
+    // The message text changed across HDF5 versions ("(?:synchronously)?"), codes did not
+    assert!(err.contains_major(hdf5::MajorErrorCode::Dataset), "{err:?}");
+    assert!(err.contains_minor(hdf5::MinorErrorCode::CantSet), "{err:?}");
+
+    // A chunked dataset with an unlimited axis resizes without error.
+    let ds = file.new_dataset::<i32>().shape((1.., 3)).chunk((4, 3)).create("resizable").unwrap();
+    ds.resize([5, 3]).unwrap();
+    assert_eq!(ds.shape(), [5, 3]);
+}
+
+#[test]
+fn test_chunk_rank_must_match_dataset_rank() {
+    let file = new_in_memory_file().unwrap();
+    // A 1-D chunk on a 2-D dataset is rejected in Rust before reaching FFI
+    let err = file.new_dataset::<i32>().shape([4, 3]).chunk([2]).create("d").unwrap_err();
+    assert_eq!(err.to_string(), "Expected chunk ndim 2, got 1");
+    assert!(err.stack().is_none(), "expected a Rust-side error, got a stack: {err:?}");
+
+    // matching rank
+    file.new_dataset::<i32>().shape([4, 3]).chunk([2, 3]).create("ok").unwrap();
 }

--- a/hdf5/tests/test_dataset.rs
+++ b/hdf5/tests/test_dataset.rs
@@ -670,9 +670,9 @@ fn test_resize_non_resizable_dataset() {
     // A dataset with contiguous storage has no maxshape and cannot be resized
     let ds = file.new_dataset::<i32>().shape([4]).create("fixed").unwrap();
     let err = ds.resize([8]).unwrap_err();
-    // The message text changed across HDF5 versions ("(?:synchronously)?"), codes did not
-    assert!(err.contains_major(hdf5::MajorErrorCode::Dataset), "{err:?}");
-    assert!(err.contains_minor(hdf5::MinorErrorCode::CantSet), "{err:?}");
+    // Minor code varies by HDF5 version, only check the major
+    let minors: Vec<_> = err.stack().unwrap().minor_codes().collect();
+    assert!(err.contains_major(hdf5::MajorErrorCode::Dataset), "minors={minors:?}: {err}");
 
     // A chunked dataset with an unlimited axis resizes without error.
     let ds = file.new_dataset::<i32>().shape((1.., 3)).chunk((4, 3)).create("resizable").unwrap();

--- a/hdf5/tests/test_plist.rs
+++ b/hdf5/tests/test_plist.rs
@@ -967,3 +967,27 @@ fn test_fapl_file_locking() -> hdf5::Result<()> {
     test_pl!(FA, file_locking: false);
     Ok(())
 }
+
+#[test]
+fn test_dcpl_filter_requires_chunking() -> hdf5::Result<()> {
+    let mut b = DatasetCreate::build();
+    b.deflate(4);
+    let err = b.finish().unwrap_err();
+    assert_eq!(err.to_string(), "Filter requires dataset to be chunked");
+    assert!(err.stack().is_none(), "expected a Rust-side error, got a stack: {err:?}");
+
+    // Adding a chunk makes it valid
+    b.chunk([4]);
+    b.finish()?;
+    Ok(())
+}
+
+#[test]
+fn test_property_list_class_from_str() {
+    assert_eq!(
+        PropertyListClass::from_str("dataset create").unwrap(),
+        PropertyListClass::DatasetCreate
+    );
+    let err = PropertyListClass::from_str("not a class").unwrap_err();
+    assert_eq!(err.to_string(), "invalid property list class: not a class");
+}


### PR DESCRIPTION
A lot of error codes and testing of error cases.

It's in error_codes.rs but for visibility, here's sources:
https://github.com/HDFGroup/hdf5/blob/hdf5_2.1.0/src/H5err.txt
https://support.hdfgroup.org/documentation/hdf5/latest/_h5_e__u_g.html

I'm planning a small follow up PR that properly resolves #191 but it needs all this plumbing :smile:   

EDIT: Obviously CI blows up, I'm taking a look...
EDIT2: This branch now also contains 2 unrelated fixes: 00a25674f3dfe9ddbef521383fb064dc0e6ee7aa and 7242fb73fc83d7bd99b8d79734b3668596c8a098 that fix a new CI lint failure and a flaky MPI job