### PR TITLE
fix big-endian float type typo

### DIFF
--- a/hdf5/src/hl/datatype.rs
+++ b/hdf5/src/hl/datatype.rs
@@ -514,7 +514,7 @@ impl Datatype {
                     #[cfg(feature = "f16")]
                     FloatSize::U2 => f16_type()?,
                     FloatSize::U4 => be_le!(H5T_IEEE_F32BE, H5T_IEEE_F32LE),
-                    FloatSize::U8 => be_le!(H5T_IEEE_I16BE, H5T_IEEE_F64LE),
+                    FloatSize::U8 => be_le!(H5T_IEEE_F64BE, H5T_IEEE_F64LE),
                 }),
                 TD::Boolean => {
                     let bool_id = h5try!(H5Tenum_create(*H5T_NATIVE_INT8));


### PR DESCRIPTION
This PR fixes a typo in the datatype handling where in big-endian systems, f64 floats are given the I16 type by accident.