### PR TITLE
Add regex for major version 2.x.y

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {version: hdf5@1.10}
           - {version: hdf5@2.1}
           - {version: hdf5}
           - {version: hdf5-mpi, mpi: true}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 ## hdf5 unreleased
 ## hdf5-derive unreleased
 ## hdf5-types unreleased
-## hdf5-sys unreleased
 ## hdf5-src unreleased
+
+
+## hdf5-sys unreleased
+- Add support for hdf5 2.2.0
+- Add symbols introduced in hdf5 2.2.0
 
 ## hdf5 0.14.0
 Release date: Jul 25, 2026

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -30,13 +30,21 @@ impl Version {
     }
 
     pub fn parse(s: &str) -> Option<Self> {
-        let re =
-            Regex::new(r"^(1|2)\.(0|1|8|10|12|14)\.(\d\d?)(_|.\d+)?((-|.)(patch)?\d+)?$").ok()?;
-        let captures = re.captures(s)?;
+        let re_v2 = Regex::new(r"^2\.(\d+)\.(\d+)(?:.+)?$").expect("Invalid regex");
+        if let Some(captures) = re_v2.captures(s) {
+            return Some(Self {
+                major: 2,
+                minor: captures.get(1).and_then(|c| c.as_str().parse::<u8>().ok())?,
+                micro: captures.get(2).and_then(|c| c.as_str().parse::<u8>().ok())?,
+            });
+        };
+        let re_v1 = Regex::new(r"^1\.(8|10|12|14)\.(\d\d?)(_|.\d+)?((-|.)(patch)?\d+)?$")
+            .expect("Invalid regex");
+        let captures = re_v1.captures(s)?;
         Some(Self {
-            major: captures.get(1).and_then(|c| c.as_str().parse::<u8>().ok())?,
-            minor: captures.get(2).and_then(|c| c.as_str().parse::<u8>().ok())?,
-            micro: captures.get(3).and_then(|c| c.as_str().parse::<u8>().ok())?,
+            major: 1,
+            minor: captures.get(1).and_then(|c| c.as_str().parse::<u8>().ok())?,
+            micro: captures.get(2).and_then(|c| c.as_str().parse::<u8>().ok())?,
         })
     }
 
@@ -54,7 +62,9 @@ impl Debug for Version {
 fn known_hdf5_versions() -> Vec<Version> {
     // Keep up to date with known_hdf5_versions in hdf5
     let mut vs = Vec::new();
-    vs.extend((0..=1).map(|v| Version::new(2, v, 0)));
+    vs.extend((0..=0).map(|v| Version::new(2, 2, v))); // 2.2.[0]
+    vs.extend((0..=1).map(|v| Version::new(2, 1, v))); // 2.1.[0-1]
+    vs.extend((0..=0).map(|v| Version::new(2, 0, v))); // 2.0.[0]
     vs.extend((5..=21).map(|v| Version::new(1, 8, v))); // 1.8.[5-23]
     vs.extend((0..=8).map(|v| Version::new(1, 10, v))); // 1.10.[0-10]
     vs.extend((0..=2).map(|v| Version::new(1, 12, v))); // 1.12.[0-2]

--- a/hdf5-sys/src/h5p.rs
+++ b/hdf5-sys/src/h5p.rs
@@ -859,3 +859,14 @@ unsafe extern "C" {
     pub unsafe fn H5Pget_virtual_spatial_tree(dcpl_id: hid_t, use_tree: *mut hbool_t) -> herr_t;
     pub unsafe fn H5Pset_virtual_spatial_tree(dapl_id: hid_t, use_tree: hbool_t) -> herr_t;
 }
+
+#[cfg(feature = "2.2.0")]
+unsafe extern "C" {
+    pub unsafe fn H5Pget_fapl_ros3_block_caching(
+        fapl_id: hid_t, block_size: *mut size_t, bloc_cache_size: *mut size_t,
+        lock_superblock: *mut hbool_t,
+    ) -> herr_t;
+    pub unsafe fn H5Pset_fapl_ros3_block_caching(
+        fapl_id: hid_t, block_size: size_t, bloc_cache_size: size_t, lock_superblock: hbool_t,
+    ) -> herr_t;
+}

--- a/hdf5/build.rs
+++ b/hdf5/build.rs
@@ -16,8 +16,9 @@ impl Version {
 fn known_hdf5_versions() -> Vec<Version> {
     // Keep up to date with known_hdf5_versions in hdf5-sys
     let mut vs = Vec::new();
-    vs.push(Version::new(2, 0, 0)); // 2.0.0
-    vs.extend((0..=1).map(|v| Version::new(2, v, 0))); // 2.[0-1].0
+    vs.extend((0..=0).map(|v| Version::new(2, 2, v))); // 2.2.[0]
+    vs.extend((0..=1).map(|v| Version::new(2, 1, v))); // 2.1.[0-1]
+    vs.extend((0..=0).map(|v| Version::new(2, 0, v))); // 2.0.[0]
     vs.extend((5..=21).map(|v| Version::new(1, 8, v))); // 1.8.[5-23]
     vs.extend((0..=8).map(|v| Version::new(1, 10, v))); // 1.10.[0-10]
     vs.extend((0..=2).map(|v| Version::new(1, 12, v))); // 1.12.[0-2]


### PR DESCRIPTION
There should be less to no breaking changes between minor versions so it should be enough to whitelist major version 2.

Fixes #198 