### PR TITLE
Add FileCreateBuilder::sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {version: hdf5@2.1}
           - {version: hdf5}
           - {version: hdf5-mpi, mpi: true}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## hdf5 unreleased
+- Added `FileCreateBuilder::sizes` and `Sizeof` to set the offset and length sizes of a file (breaking change, `SizeofInfo` holds `Sizeof` instead of `usize`)
 ## hdf5-derive unreleased
 ## hdf5-types unreleased
 ## hdf5-sys unreleased

--- a/hdf5/src/hl/file.rs
+++ b/hdf5/src/hl/file.rs
@@ -364,6 +364,7 @@ impl FileBuilder {
 
 #[cfg(test)]
 pub mod tests {
+    use crate::file::{FileCreate, Sizeof, SizeofInfo};
     use crate::internal_prelude::*;
     use std::fs;
     use std::io::{Read, Write};
@@ -509,6 +510,24 @@ pub mod tests {
             assert!(new_size > orig_size);
             assert_eq!(file.size(), new_size);
         })
+    }
+
+    #[test]
+    pub fn test_sizes() {
+        let sizes = SizeofInfo { sizeof_addr: Sizeof::Bytes4, sizeof_size: Sizeof::Bytes2 };
+        with_tmp_file(|file| {
+            assert_eq!(file.fcpl().unwrap().sizes(), SizeofInfo::default());
+        });
+        with_tmp_path(|path| {
+            FileBuilder::new().with_fcpl(|p| p.sizes(sizes)).create(&path).unwrap();
+            assert_eq!(File::open(&path).unwrap().fcpl().unwrap().sizes(), sizes);
+        });
+        // a property list handed to the builder keeps its sizes
+        with_tmp_path(|path| {
+            let fcpl = FileCreate::build().sizes(sizes).finish().unwrap();
+            FileBuilder::new().set_fcpl(&fcpl).unwrap().create(&path).unwrap();
+            assert_eq!(File::open(&path).unwrap().fcpl().unwrap().sizes(), sizes);
+        });
     }
 
     #[test]

--- a/hdf5/src/hl/plist/file_create.rs
+++ b/hdf5/src/hl/plist/file_create.rs
@@ -17,7 +17,7 @@ use hdf5_sys::h5p::{
     H5Pget_shared_mesg_phase_change, H5Pget_sizes, H5Pget_sym_k, H5Pget_userblock,
     H5Pset_attr_creation_order, H5Pset_attr_phase_change, H5Pset_istore_k, H5Pset_obj_track_times,
     H5Pset_shared_mesg_index, H5Pset_shared_mesg_nindexes, H5Pset_shared_mesg_phase_change,
-    H5Pset_sym_k, H5Pset_userblock,
+    H5Pset_sizes, H5Pset_sym_k, H5Pset_userblock,
 };
 #[cfg(feature = "1.10.1")]
 use hdf5_sys::h5p::{
@@ -93,13 +93,54 @@ impl PartialEq for FileCreate {
 
 impl Eq for FileCreate {}
 
+/// Byte size of the offset and length fields of a file.
+///
+/// Every file address and every length stored in an HDF5 file is encoded at
+/// one of these sizes. The sizes are fixed when the file is created, see
+/// [`FileCreateBuilder::sizes`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Sizeof {
+    /// 2 bytes.
+    Bytes2 = 2,
+    /// 4 bytes.
+    Bytes4 = 4,
+    /// 8 bytes, the default.
+    #[default]
+    Bytes8 = 8,
+    /// 16 bytes.
+    Bytes16 = 16,
+}
+
+impl From<Sizeof> for usize {
+    fn from(sizeof: Sizeof) -> Self {
+        sizeof as Self
+    }
+}
+
+impl TryFrom<usize> for Sizeof {
+    type Error = Error;
+
+    fn try_from(bytes: usize) -> Result<Self> {
+        match bytes {
+            2 => Ok(Self::Bytes2),
+            4 => Ok(Self::Bytes4),
+            8 => Ok(Self::Bytes8),
+            16 => Ok(Self::Bytes16),
+            _ => Err(format!("invalid offset or length size: {bytes}").into()),
+        }
+    }
+}
+
 /// Size of the offsets and lengths used in a file.
+///
+/// The two sizes are independent: the offset size bounds the size of the
+/// file and the length size bounds the size of an object in it.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct SizeofInfo {
-    /// Offset size in bytes.
-    pub sizeof_addr: usize,
-    /// Length size in bytes.
-    pub sizeof_size: usize,
+    /// Size of every file address ("Size of Offsets").
+    pub sizeof_addr: Sizeof,
+    /// Size of every length field ("Size of Lengths").
+    pub sizeof_size: Sizeof,
 }
 
 /// Size of parameters used to control the symbol table nodes.
@@ -220,6 +261,7 @@ impl Default for FileSpaceStrategy {
 #[derive(Clone, Debug, Default)]
 pub struct FileCreateBuilder {
     userblock: Option<u64>,
+    sizes: Option<SizeofInfo>,
     sym_k: Option<SymbolTableInfo>,
     istore_k: Option<u32>,
     shared_mesg_phase_change: Option<PhaseChangeInfo>,
@@ -243,6 +285,7 @@ impl FileCreateBuilder {
     pub fn from_plist(plist: &FileCreate) -> Result<Self> {
         let mut builder = Self::default();
         builder.userblock(plist.get_userblock()?);
+        builder.sizes(plist.get_sizes()?);
         let v = plist.get_sym_k()?;
         builder.sym_k(v.tree_rank, v.node_size);
         builder.istore_k(plist.get_istore_k()?);
@@ -268,6 +311,31 @@ impl FileCreateBuilder {
     /// greater (512, 1024, 2048, etc.).
     pub fn userblock(&mut self, size: u64) -> &mut Self {
         self.userblock = Some(size);
+        self
+    }
+
+    /// Sets the byte size of the offset and length fields of the file.
+    ///
+    /// Every file address is stored at `sizeof_addr` bytes and every length
+    /// at `sizeof_size` bytes. Both default to [`Sizeof::Bytes8`]. A smaller
+    /// size makes every metadata structure smaller and limits the size of the
+    /// file, or of an object in it, to what the field can address.
+    ///
+    /// This setting cannot be changed for the life of the file.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hdf5_metno::plist::FileCreateBuilder;
+    /// use hdf5_metno::plist::file_create::{Sizeof, SizeofInfo};
+    ///
+    /// let sizes = SizeofInfo { sizeof_addr: Sizeof::Bytes4, sizeof_size: Sizeof::Bytes8 };
+    /// let fcpl = FileCreateBuilder::new().sizes(sizes).finish()?;
+    /// assert_eq!(fcpl.sizes(), sizes);
+    /// # Ok::<(), hdf5_metno::Error>(())
+    /// ```
+    pub fn sizes(&mut self, sizes: SizeofInfo) -> &mut Self {
+        self.sizes = Some(sizes);
         self
     }
 
@@ -367,6 +435,13 @@ impl FileCreateBuilder {
         if let Some(v) = self.userblock {
             h5try!(H5Pset_userblock(id, v as _));
         }
+        if let Some(v) = self.sizes {
+            h5try!(H5Pset_sizes(
+                id,
+                usize::from(v.sizeof_addr) as _,
+                usize::from(v.sizeof_size) as _
+            ));
+        }
         if let Some(v) = self.sym_k {
             h5try!(H5Pset_sym_k(id, v.tree_rank as _, v.node_size as _));
         }
@@ -462,8 +537,10 @@ impl FileCreate {
 
     #[doc(hidden)]
     pub fn get_sizes(&self) -> Result<SizeofInfo> {
-        h5get!(H5Pget_sizes(self.id()): size_t, size_t).map(|(sizeof_addr, sizeof_size)| {
-            SizeofInfo { sizeof_addr: sizeof_addr as _, sizeof_size: sizeof_size as _ }
+        let (sizeof_addr, sizeof_size) = h5get!(H5Pget_sizes(self.id()): size_t, size_t)?;
+        Ok(SizeofInfo {
+            sizeof_addr: Sizeof::try_from(sizeof_addr as usize)?,
+            sizeof_size: Sizeof::try_from(sizeof_size as usize)?,
         })
     }
 
@@ -542,7 +619,7 @@ impl FileCreate {
 
     /// Retrieves the size of the offsets and lengths used in the file.
     pub fn sizes(&self) -> SizeofInfo {
-        self.get_sizes().unwrap_or_else(|_| SizeofInfo::default())
+        self.get_sizes().unwrap_or_default()
     }
 
     /// Retrieves the size of the symbol table B-tree 1/2 rank and the symbol

--- a/hdf5/tests/test_plist.rs
+++ b/hdf5/tests/test_plist.rs
@@ -81,10 +81,9 @@ fn test_fcpl_common() -> hdf5::Result<()> {
 
 #[test]
 fn test_fcpl_sizes() -> hdf5::Result<()> {
-    use hdf5_sys::h5::hsize_t;
     let fcpl = FileCreate::try_new()?;
-    assert_eq!(fcpl.sizes().sizeof_addr, mem::size_of::<hsize_t>());
-    assert_eq!(fcpl.sizes().sizeof_size, mem::size_of::<hsize_t>());
+    assert_eq!(fcpl.sizes().sizeof_addr, Sizeof::Bytes8);
+    assert_eq!(fcpl.sizes().sizeof_size, Sizeof::Bytes8);
     Ok(())
 }
 
@@ -92,6 +91,13 @@ fn test_fcpl_sizes() -> hdf5::Result<()> {
 fn test_fcpl_set_userblock() -> hdf5::Result<()> {
     test_pl!(FC, userblock: 0);
     test_pl!(FC, userblock: 4096);
+    Ok(())
+}
+
+#[test]
+fn test_fcpl_set_sizes() -> hdf5::Result<()> {
+    test_pl!(FC, sizes: SizeofInfo { sizeof_addr: Sizeof::Bytes2, sizeof_size: Sizeof::Bytes4 });
+    test_pl!(FC, sizes: SizeofInfo { sizeof_addr: Sizeof::Bytes8, sizeof_size: Sizeof::Bytes16 });
     Ok(())
 }
 


### PR DESCRIPTION
resolves #211 

It's a bit ugly with all the repetitive "sizeof_sizeof_size" but the value is in keeping it closely in line with libhdf5 naming