### PR TITLE
Accept an existing datatype in empty_as and with_data_as

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
           cargo r --example simple --features ${{ env.FEATURES }}
           cargo r --example chunking --features ${{ env.FEATURES }}
           cargo r --example continuously_rw_1d --features ${{ env.FEATURES }}
+          cargo r --example committed_datatype --features ${{ env.FEATURES }}
+          cargo r --example swmr --features ${{ env.FEATURES }}
         if: matrix.rust != 'stable-gnu'
         env:
           FEATURES: hdf5-sys/static,hdf5-sys/zlib,lzf,blosc-all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added `Group::commit_datatype`, `Group::committed_datatype` and `Group::committed_datatypes`
 - Deprecated `Group::named_datatypes`, use `Group::committed_datatypes` instead
 - Added `CommittedDatatype` with attribute access, returned by `Group::committed_datatype`, `Group::committed_datatypes` and the deprecated `Group::named_datatypes` (breaking change)
-- `DatasetBuilder::empty_as` and `DatasetBuilder::with_data_as` accept an existing `Datatype` or `CommittedDatatype` as well as a `TypeDescriptor`, through the new `DatasetType`, so a dataset can be created with a committed datatype. A committed datatype from another file is rejected on HDF5 versions before 1.8.18 and on 1.10.0, which cannot store it
+- Changed `DatasetBuilder::empty_as` and `DatasetBuilder::with_data_as` to accept an existing `Datatype` or `CommittedDatatype` as well as a `TypeDescriptor`, through the new `DatasetType`, so a dataset can be created with a committed datatype.
 - Added `FileCreateBuilder::sizes` and `Sizeof` to set the offset and length sizes of a file (breaking change, `SizeofInfo` holds `Sizeof` instead of `usize`)
 - Added more variants to `LibraryVersion`. If you specified `Latest` before you may start generating files which are no longer compatible with earlier versions of `hdf5`
 ## hdf5-derive unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `Group::commit_datatype`, `Group::committed_datatype` and `Group::committed_datatypes`
 - Deprecated `Group::named_datatypes`, use `Group::committed_datatypes` instead
 - Added `CommittedDatatype` with attribute access, returned by `Group::committed_datatype`, `Group::committed_datatypes` and the deprecated `Group::named_datatypes` (breaking change)
+- `DatasetBuilder::empty_as` and `DatasetBuilder::with_data_as` accept an existing `Datatype` or `CommittedDatatype` as well as a `TypeDescriptor`, through the new `DatasetType`, so a dataset can be created with a committed datatype. A committed datatype from another file is rejected on HDF5 versions before 1.8.18 and on 1.10.0, which cannot store it
 - Added `FileCreateBuilder::sizes` and `Sizeof` to set the offset and length sizes of a file (breaking change, `SizeofInfo` holds `Sizeof` instead of `usize`)
 - Added more variants to `LibraryVersion`. If you specified `Latest` before you may start generating files which are no longer compatible with earlier versions of `hdf5`
 ## hdf5-derive unreleased

--- a/hdf5/examples/committed_datatype.rs
+++ b/hdf5/examples/committed_datatype.rs
@@ -1,0 +1,114 @@
+//! Share one record type across many datasets with a committed datatype
+//!
+//! A datatype built from a Rust type is transient: every dataset created from it stores its own
+//! copy of the type. A committed datatype is an object in the file. Datasets created from it through
+//! `DatasetBuilder::empty_as` or `with_data_as` refer to that object instead of copying it, so the record
+//! layout is described once, can be documented with attributes, and can be looked up by name.
+
+use hdf5::types::VarLenUnicode;
+use hdf5::{Datatype, File, H5Type, Result};
+use hdf5_metno as hdf5;
+
+#[derive(H5Type, Clone, Copy, Debug, PartialEq)]
+#[repr(i8)]
+enum Quality {
+    Good = 0,
+    Suspect = 1,
+    Missing = 2,
+}
+
+#[derive(H5Type, Clone, Debug, PartialEq)]
+#[repr(C)]
+struct Sample {
+    time: f64,
+    value: f32,
+    quality: Quality,
+}
+
+const FILE_NAME: &str = "committed_datatype.h5";
+const SCHEMA: &str = "types/sample";
+
+fn samples(offset: f32) -> Vec<Sample> {
+    (0..4)
+        .map(|i| Sample {
+            time: 60.0 * f64::from(i),
+            value: offset + i as f32,
+            quality: match i {
+                2 => Quality::Suspect,
+                3 => Quality::Missing,
+                _ => Quality::Good,
+            },
+        })
+        .collect()
+}
+
+fn write() -> Result<()> {
+    let file = File::create(FILE_NAME)?;
+
+    // Commit the record type once, at a path readers can look up.
+    let sample = Datatype::from_type::<Sample>()?;
+    file.create_group("types")?;
+    file.commit_datatype(SCHEMA, &sample)?;
+
+    // A committed datatype is an object, so it can carry attributes that document the layout.
+    let schema = file.committed_datatype(SCHEMA)?;
+    schema.new_attr::<u32>().create("schema_version")?.write_scalar(&1)?;
+    let unit: VarLenUnicode = "seconds since 2024-01-01T00:00:00Z".parse().unwrap();
+    schema.new_attr::<VarLenUnicode>().create("time_unit")?.write_scalar(&unit)?;
+
+    // Every station dataset refers to the committed type instead of storing a copy.
+    for (i, station) in ["oslo", "bergen"].iter().enumerate() {
+        let data = samples(10.0 * i as f32);
+        file.new_dataset_builder()
+            .with_data_as(&data, &sample)
+            .create(format!("stations/{station}").as_str())?;
+    }
+
+    // For contrast, a dataset built from the Rust type alone gets a transient copy of the type.
+    let copy = file.new_dataset::<Sample>().shape(1).create("scratch")?;
+    assert!(!copy.dtype()?.is_committed());
+    Ok(())
+}
+
+fn append_station() -> Result<()> {
+    let file = File::open_rw(FILE_NAME)?;
+
+    // The type of an existing dataset is the committed type, so it creates more of the same.
+    let template = file.dataset("stations/oslo")?.dtype()?;
+    assert!(template.is_committed());
+    let data = samples(20.0);
+    file.new_dataset_builder()
+        .empty_as(&template)
+        .shape(data.len())
+        .create("stations/tromso")?
+        .write(&data)?;
+    Ok(())
+}
+
+fn read() -> Result<()> {
+    let file = File::open(FILE_NAME)?;
+
+    // The schema and its documentation are found by name, without opening any dataset.
+    let schema = file.committed_datatype(SCHEMA)?;
+    let version = schema.attr("schema_version")?.read_scalar::<u32>()?;
+    let unit = schema.attr("time_unit")?.read_scalar::<VarLenUnicode>()?;
+    println!("schema {} version {version}, time in {unit}", schema.name());
+    println!("layout: {:?}", schema.as_datatype().to_descriptor()?);
+
+    // Every dataset created from the schema reports the committed type.
+    let stations = file.group("stations")?;
+    for name in stations.member_names()? {
+        let ds = stations.dataset(&name)?;
+        assert!(ds.dtype()?.is_committed());
+        let data = ds.read_1d::<Sample>()?;
+        let suspect = data.iter().filter(|s| s.quality != Quality::Good).count();
+        println!("{name}: {} samples, {suspect} flagged", data.len());
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    write()?;
+    append_station()?;
+    read()
+}

--- a/hdf5/src/hl.rs
+++ b/hdf5/src/hl.rs
@@ -24,6 +24,7 @@ pub use self::{
     container::{ByteReader, Container, Reader, Writer},
     dataset::{
         Dataset, DatasetBuilder, DatasetBuilderData, DatasetBuilderEmpty, DatasetBuilderEmptyShape,
+        DatasetType,
     },
     dataspace::Dataspace,
     datatype::{Conversion, Datatype},

--- a/hdf5/src/hl/dataset.rs
+++ b/hdf5/src/hl/dataset.rs
@@ -289,8 +289,10 @@ impl DatasetBuilder {
 ///
 /// A descriptor becomes a transient datatype when the dataset is created, laid out as
 /// [`packed`](DatasetBuilder::packed) says. An existing datatype is passed to `H5Dcreate2`
-/// as is, so `packed` is rejected for it. With a committed datatype the dataset stores a
-/// reference to the committed type instead of a copy of it.
+/// as is, so `packed` is rejected for it. With a committed datatype from the same file the
+/// dataset stores a reference to the committed type instead of a copy of it. A committed
+/// datatype from another file is stored as a copy from HDF5 1.8.18 and 1.10.1 on, and is
+/// rejected on older libraries, which would write a reference the file cannot resolve.
 #[derive(Clone, Debug)]
 pub enum DatasetType {
     /// A descriptor, turned into a transient datatype when the dataset is created.
@@ -620,10 +622,38 @@ impl DatasetBuilderInner {
             }
             DatasetType::Datatype(dtype) => {
                 ensure!(!self.packed, "packed layout cannot be applied to an existing datatype");
+                #[cfg(not(any(
+                    all(feature = "1.8.18", not(feature = "1.10.0")),
+                    feature = "1.10.1"
+                )))]
+                self.ensure_same_file(dtype)?;
                 dtype.clone()
             }
         };
         self.create_dataset(&dtype, name, extents)
+    }
+
+    /// Rejects a committed datatype that lives in another file than the dataset.
+    ///
+    /// Libraries before 1.8.18, and 1.10.0, write such a dataset with a reference into
+    /// the other file, and the dataset cannot be opened again. Later libraries store a
+    /// copy of the type instead, so they need no check.
+    #[cfg(not(any(all(feature = "1.8.18", not(feature = "1.10.0")), feature = "1.10.1")))]
+    fn ensure_same_file(&self, dtype: &Datatype) -> Result<()> {
+        use crate::hl::location::H5O_get_info;
+
+        if !dtype.is_committed() {
+            return Ok(());
+        }
+        let parent = try_ref_clone!(self.parent);
+        let parent_file = H5O_get_info(parent.id(), false)?.fileno;
+        let dtype_file = H5O_get_info(dtype.id(), false)?.fileno;
+        ensure!(
+            parent_file == dtype_file,
+            "committed datatype is in a different file than the dataset, which this HDF5 \
+             version cannot store"
+        );
+        Ok(())
     }
 
     /// Creates the dataset with `dtype`, the property lists and the dataspace.

--- a/hdf5/src/hl/dataset.rs
+++ b/hdf5/src/hl/dataset.rs
@@ -220,8 +220,9 @@ impl DatasetBuilder {
         self.empty_as(&T::type_descriptor())
     }
 
-    pub fn empty_as(self, type_desc: &TypeDescriptor) -> DatasetBuilderEmpty {
-        DatasetBuilderEmpty { builder: self.builder, type_desc: type_desc.clone() }
+    /// Sets the dataset's type from a descriptor or an existing datatype, see [`DatasetType`].
+    pub fn empty_as(self, dtype: impl Into<DatasetType>) -> DatasetBuilderEmpty {
+        DatasetBuilderEmpty { builder: self.builder, dtype: dtype.into() }
     }
 
     pub fn with_data<'d, A, T, D>(self, data: A) -> DatasetBuilderData<'d, T, D>
@@ -230,11 +231,13 @@ impl DatasetBuilder {
         T: H5Type,
         D: ndarray::Dimension,
     {
-        self.with_data_as::<A, T, D>(data, &T::type_descriptor())
+        self.with_data_as::<A, T, D>(data, T::type_descriptor())
     }
 
+    /// Sets the dataset's data and its type from a descriptor or an existing datatype, see
+    /// [`DatasetType`].
     pub fn with_data_as<'d, A, T, D>(
-        self, data: A, type_desc: &TypeDescriptor,
+        self, data: A, dtype: impl Into<DatasetType>,
     ) -> DatasetBuilderData<'d, T, D>
     where
         A: Into<ArrayView<'d, T, D>>,
@@ -244,7 +247,7 @@ impl DatasetBuilder {
         DatasetBuilderData {
             builder: self.builder,
             data: data.into(),
-            type_desc: type_desc.clone(),
+            dtype: dtype.into(),
             conv: Conversion::Soft,
         }
     }
@@ -278,18 +281,82 @@ impl DatasetBuilder {
     // }
 }
 
+/// The type a dataset is created with.
+///
+/// [`DatasetBuilder::empty_as`] and [`DatasetBuilder::with_data_as`] take anything that
+/// converts into it: a [`TypeDescriptor`], a [`Datatype`] or a [`CommittedDatatype`], by
+/// value or by reference.
+///
+/// A descriptor becomes a transient datatype when the dataset is created, laid out as
+/// [`packed`](DatasetBuilder::packed) says. An existing datatype is passed to `H5Dcreate2`
+/// as is, so `packed` is rejected for it. With a committed datatype the dataset stores a
+/// reference to the committed type instead of a copy of it.
+#[derive(Clone, Debug)]
+pub enum DatasetType {
+    /// A descriptor, turned into a transient datatype when the dataset is created.
+    Descriptor(TypeDescriptor),
+    /// An existing datatype, used as is.
+    Datatype(Datatype),
+}
+
+impl DatasetType {
+    /// The datatype the data is converted to, for checking the conversion.
+    fn to_datatype(&self) -> Result<Datatype> {
+        match self {
+            Self::Descriptor(desc) => Datatype::from_descriptor(desc),
+            Self::Datatype(dtype) => Ok(dtype.clone()),
+        }
+    }
+}
+
+impl From<TypeDescriptor> for DatasetType {
+    fn from(desc: TypeDescriptor) -> Self {
+        Self::Descriptor(desc)
+    }
+}
+
+impl From<&TypeDescriptor> for DatasetType {
+    fn from(desc: &TypeDescriptor) -> Self {
+        Self::Descriptor(desc.clone())
+    }
+}
+
+impl From<Datatype> for DatasetType {
+    fn from(dtype: Datatype) -> Self {
+        Self::Datatype(dtype)
+    }
+}
+
+impl From<&Datatype> for DatasetType {
+    fn from(dtype: &Datatype) -> Self {
+        Self::Datatype(dtype.clone())
+    }
+}
+
+impl From<CommittedDatatype> for DatasetType {
+    fn from(dtype: CommittedDatatype) -> Self {
+        Self::Datatype(dtype.as_datatype().clone())
+    }
+}
+
+impl From<&CommittedDatatype> for DatasetType {
+    fn from(dtype: &CommittedDatatype) -> Self {
+        Self::Datatype(dtype.as_datatype().clone())
+    }
+}
+
 #[derive(Clone)]
 /// A dataset builder with the type known
 pub struct DatasetBuilderEmpty {
     builder: DatasetBuilderInner,
-    type_desc: TypeDescriptor,
+    dtype: DatasetType,
 }
 
 impl DatasetBuilderEmpty {
     pub fn shape<S: Into<Extents>>(self, extents: S) -> DatasetBuilderEmptyShape {
         DatasetBuilderEmptyShape {
             builder: self.builder,
-            type_desc: self.type_desc,
+            dtype: self.dtype,
             extents: extents.into(),
         }
     }
@@ -302,13 +369,13 @@ impl DatasetBuilderEmpty {
 /// A dataset builder with type and shape known
 pub struct DatasetBuilderEmptyShape {
     builder: DatasetBuilderInner,
-    type_desc: TypeDescriptor,
+    dtype: DatasetType,
     extents: Extents,
 }
 
 impl DatasetBuilderEmptyShape {
     pub fn create<'n, T: Into<Maybe<&'n str>>>(&self, name: T) -> Result<Dataset> {
-        h5lock!(self.builder.create(&self.type_desc, name.into().into(), &self.extents))
+        h5lock!(self.builder.create(&self.dtype, name.into().into(), &self.extents))
     }
 }
 
@@ -317,7 +384,7 @@ impl DatasetBuilderEmptyShape {
 pub struct DatasetBuilderData<'d, T, D> {
     builder: DatasetBuilderInner,
     data: ArrayView<'d, T, D>,
-    type_desc: TypeDescriptor,
+    dtype: DatasetType,
     conv: Conversion,
 }
 
@@ -347,9 +414,9 @@ where
         let name = name.into().into();
         h5lock!({
             let dtype_src = Datatype::from_type::<T>()?;
-            let dtype_dst = Datatype::from_descriptor(&self.type_desc)?;
+            let dtype_dst = self.dtype.to_datatype()?;
             dtype_src.ensure_convertible(&dtype_dst, self.conv)?;
-            let ds = self.builder.create(&self.type_desc, name, &extents)?;
+            let ds = self.builder.create(&self.dtype, name, &extents)?;
             if let Err(err) = ds.write(self.data.view()) {
                 self.builder.try_unlink(name);
                 Err(err)
@@ -537,13 +604,37 @@ impl DatasetBuilderInner {
         }
     }
 
+    /// Creates the dataset with the in-file datatype built from `dtype`.
+    ///
+    /// # Safety
+    ///
+    /// Must be called with the library lock held, see `h5lock!`.
     unsafe fn create(
-        &self, desc: &TypeDescriptor, name: Option<&str>, extents: &Extents,
+        &self, dtype: &DatasetType, name: Option<&str>, extents: &Extents,
     ) -> Result<Dataset> {
-        // construct in-file type descriptor; convert to packed representation if needed
-        let desc = if self.packed { desc.to_packed_repr() } else { desc.to_c_repr() };
-        let dtype = Datatype::from_descriptor(&desc)?;
+        let dtype = match dtype {
+            DatasetType::Descriptor(desc) => {
+                // build the in-file type from the descriptor, packed if requested
+                let desc = if self.packed { desc.to_packed_repr() } else { desc.to_c_repr() };
+                Datatype::from_descriptor(&desc)?
+            }
+            DatasetType::Datatype(dtype) => {
+                ensure!(!self.packed, "packed layout cannot be applied to an existing datatype");
+                dtype.clone()
+            }
+        };
+        self.create_dataset(&dtype, name, extents)
+    }
 
+    /// Creates the dataset with `dtype`, the property lists and the dataspace.
+    ///
+    /// # Safety
+    ///
+    /// Must be called with the library lock held, see `h5lock!`. The raw
+    /// `H5Dcreate2` and `H5Dcreate_anon` calls below rely on it.
+    unsafe fn create_dataset(
+        &self, dtype: &Datatype, name: Option<&str>, extents: &Extents,
+    ) -> Result<Dataset> {
         // construct DAPL and DCPL, validate filters
         let dapl = self.build_dapl()?;
         let dcpl = self.build_dcpl(&dtype, extents)?;
@@ -1110,7 +1201,8 @@ mod tests {
     use super::{DatasetBuilder, compute_chunk_shape};
     use crate::filters::Filter;
     use crate::test::with_tmp_file;
-    use crate::{Extent, Result, SimpleExtents};
+    use crate::{Datatype, Error, Extent, Result, SimpleExtents};
+    use hdf5_types::{IntSize, TypeDescriptor};
 
     #[cfg(feature = "blosc")]
     use crate::filters::{Blosc, BloscShuffle};
@@ -1171,6 +1263,62 @@ mod tests {
 
         let e = SimpleExtents::new(&[1, 1, 100]);
         assert_eq!(compute_chunk_shape(&e, 51), vec![1, 1, 100]);
+    }
+
+    #[test]
+    fn test_empty_as_datatype() {
+        with_tmp_file(|file| {
+            let dtype = Datatype::from_type::<i32>().unwrap();
+            let ds = file.new_dataset_builder().empty_as(&dtype).shape(3).create("x").unwrap();
+            let stored = ds.dtype().unwrap();
+            assert!(!stored.is_committed());
+            assert_eq!(stored.to_descriptor().unwrap(), dtype.to_descriptor().unwrap());
+            assert_eq!(ds.shape(), vec![3]);
+        })
+    }
+
+    #[test]
+    fn test_empty_as_datatype_rejects_packed() {
+        with_tmp_file(|file| {
+            let dtype = Datatype::from_type::<i32>().unwrap();
+            let err = file.new_dataset_builder().packed(true).empty_as(&dtype).create("x");
+            assert!(matches!(err, Err(Error::Internal(_))));
+            assert!(file.dataset("x").is_err());
+        })
+    }
+
+    #[test]
+    fn test_with_data_as_datatype() {
+        with_tmp_file(|file| {
+            let dtype = Datatype::from_type::<i64>().unwrap();
+            let ds =
+                file.new_dataset_builder().with_data_as(&[1_i32, 2], &dtype).create("x").unwrap();
+            assert_eq!(
+                ds.dtype().unwrap().to_descriptor().unwrap(),
+                dtype.to_descriptor().unwrap()
+            );
+            assert_eq!(ds.read_1d::<i64>().unwrap().to_vec(), vec![1, 2]);
+        })
+    }
+
+    #[test]
+    fn test_with_data_as_datatype_rejects_packed() {
+        with_tmp_file(|file| {
+            let dtype = Datatype::from_type::<i32>().unwrap();
+            let err =
+                file.new_dataset_builder().packed(true).with_data_as(&[1_i32], &dtype).create("x");
+            assert!(matches!(err, Err(Error::Internal(_))));
+            assert!(file.dataset("x").is_err());
+        })
+    }
+
+    #[test]
+    fn test_dataset_type_from_descriptor_by_value() {
+        with_tmp_file(|file| {
+            let desc = TypeDescriptor::Integer(IntSize::U2);
+            let ds = file.new_dataset_builder().empty_as(desc.clone()).create("x").unwrap();
+            assert_eq!(ds.dtype().unwrap().to_descriptor().unwrap(), desc);
+        })
     }
 
     #[test]

--- a/hdf5/src/hl/location.rs
+++ b/hdf5/src/hl/location.rs
@@ -342,7 +342,7 @@ fn info_fields(full: bool) -> c_uint {
 }
 
 #[allow(non_snake_case, unused_variables)]
-fn H5O_get_info(loc_id: hid_t, full: bool) -> Result<LocationInfo> {
+pub(crate) fn H5O_get_info(loc_id: hid_t, full: bool) -> Result<LocationInfo> {
     let mut info_buf = MaybeUninit::uninit();
     let info_ptr = info_buf.as_mut_ptr();
     #[cfg(feature = "1.12.0")]

--- a/hdf5/src/lib.rs
+++ b/hdf5/src/lib.rs
@@ -63,9 +63,9 @@ mod export {
             Attribute, AttributeBuilder, AttributeBuilderData, AttributeBuilderEmpty,
             AttributeBuilderEmptyShape, ByteReader, CommittedDatatype, Container, Conversion,
             Dataset, DatasetBuilder, DatasetBuilderData, DatasetBuilderEmpty,
-            DatasetBuilderEmptyShape, Dataspace, Datatype, File, FileBuilder, Group, GroupBuilder,
-            LinkInfo, LinkType, Location, LocationInfo, LocationToken, LocationType, Object,
-            OpenMode, PropertyList, Reader, Writer,
+            DatasetBuilderEmptyShape, DatasetType, Dataspace, Datatype, File, FileBuilder, Group,
+            GroupBuilder, LinkInfo, LinkType, Location, LocationInfo, LocationToken, LocationType,
+            Object, OpenMode, PropertyList, Reader, Writer,
             references::{ObjectReference, ObjectReference1, ReferencedObject},
         },
     };

--- a/hdf5/tests/test_dataset.rs
+++ b/hdf5/tests/test_dataset.rs
@@ -6,7 +6,9 @@ use ndarray::{Array1, Array2, ArrayD, IxDyn, SliceInfo, s};
 use rand::prelude::{Rng, RngExt, SeedableRng, SmallRng};
 
 use hdf5_metno as hdf5;
-use hdf5_types::TypeDescriptor;
+use hdf5_metno::H5Type;
+use hdf5_types::{TypeDescriptor, VarLenUnicode};
+use tempfile::tempdir;
 
 mod common;
 
@@ -626,6 +628,189 @@ fn test_create_on_databuilder() {
     let _ds = file.new_dataset_builder().with_data(&[1_i32, 2, 3]).create("ds2").unwrap();
     let _ds = file.new_dataset::<i32>().create("ds3").unwrap();
     let _ds = file.new_dataset::<i32>().shape(2).create("ds4").unwrap();
+}
+
+#[derive(H5Type, Clone, Debug, PartialEq)]
+#[repr(C)]
+struct Point {
+    x: f64,
+    tag: i32,
+}
+
+#[test]
+fn test_create_with_committed_datatype() -> hdf5::Result<()> {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("committed.h5");
+    let dtype = hdf5::Datatype::from_type::<Point>()?;
+    {
+        let file = hdf5::File::create(&path)?;
+        file.commit_datatype("point", &dtype)?;
+        file.new_dataset_builder().empty_as(&dtype).shape(2).create("pair")?;
+        file.new_dataset_builder().empty_as(&dtype).create("single")?;
+    }
+
+    let file = hdf5::File::open_rw(&path)?;
+    let expected = file.committed_datatype("point")?.as_datatype().to_descriptor()?;
+    let pair = file.dataset("pair")?;
+    let single = file.dataset("single")?;
+    for ds in [&pair, &single] {
+        let stored = ds.dtype()?;
+        assert!(stored.is_committed());
+        assert_eq!(stored.to_descriptor()?, expected);
+    }
+
+    let values = [Point { x: 1.5, tag: 1 }, Point { x: -2.0, tag: 2 }];
+    pair.write(&values)?;
+    assert_eq!(pair.read_1d::<Point>()?.as_slice().unwrap(), &values);
+    single.write_scalar(&values[0])?;
+    assert_eq!(single.read_scalar::<Point>()?, values[0]);
+    Ok(())
+}
+
+#[test]
+fn test_empty_as_datatype_reuses_dataset_type() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let dtype = hdf5::Datatype::from_type::<Point>()?;
+    file.commit_datatype("point", &dtype)?;
+    let first = file.new_dataset_builder().empty_as(&dtype).create("first")?;
+
+    let second = file.new_dataset_builder().empty_as(&first.dtype()?).create("second")?;
+    assert!(second.dtype()?.is_committed());
+    assert_eq!(second.dtype()?.to_descriptor()?, dtype.to_descriptor()?);
+    assert_eq!(file.committed_datatypes()?.len(), 1);
+    Ok(())
+}
+
+#[test]
+fn test_empty_as_datatype_from_other_file_stores_copy() -> hdf5::Result<()> {
+    let origin = new_in_memory_file()?;
+    let dtype = hdf5::Datatype::from_type::<Point>()?;
+    origin.commit_datatype("point", &dtype)?;
+
+    let file = new_in_memory_file()?;
+    let ds = file.new_dataset_builder().empty_as(&dtype).create("copy")?;
+    assert!(!ds.dtype()?.is_committed());
+    assert_eq!(ds.dtype()?.to_descriptor()?, dtype.to_descriptor()?);
+    assert!(file.committed_datatypes()?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn test_empty_as_datatype_outlives_unlinked_type() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let dtype = hdf5::Datatype::from_type::<Point>()?;
+    file.commit_datatype("point", &dtype)?;
+    let ds = file.new_dataset_builder().empty_as(&dtype).create("ds")?;
+
+    file.unlink("point")?;
+    assert!(file.committed_datatypes()?.is_empty());
+    assert!(ds.dtype()?.is_committed());
+    let value = Point { x: 0.5, tag: 7 };
+    ds.write_scalar(&value)?;
+    assert_eq!(ds.read_scalar::<Point>()?, value);
+    Ok(())
+}
+
+#[test]
+fn test_empty_as_datatype_leaves_transient_type_reusable() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let dtype = hdf5::Datatype::from_type::<Point>()?;
+    let first = file.new_dataset_builder().empty_as(&dtype).create("first")?;
+    assert!(!first.dtype()?.is_committed());
+
+    assert!(!dtype.is_committed());
+    let second = file.new_dataset_builder().empty_as(&dtype).create("second")?;
+    assert_eq!(second.dtype()?.to_descriptor()?, dtype.to_descriptor()?);
+    Ok(())
+}
+
+#[test]
+fn test_empty_as_datatype_anonymous_dataset() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let dtype = hdf5::Datatype::from_type::<Point>()?;
+    file.commit_datatype("point", &dtype)?;
+
+    let ds = file.new_dataset_builder().empty_as(&dtype).create(None)?;
+    assert!(ds.dtype()?.is_committed());
+    assert!(file.member_names()?.iter().all(|name| name == "point"));
+    Ok(())
+}
+
+#[test]
+fn test_empty_as_datatype_chunked_and_filtered() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let dtype = hdf5::Datatype::from_type::<Point>()?;
+    file.commit_datatype("point", &dtype)?;
+
+    let ds = file
+        .new_dataset_builder()
+        .empty_as(&dtype)
+        .chunk(2)
+        .shuffle()
+        .fletcher32()
+        .shape(4)
+        .create("ds")?;
+    assert!(ds.dtype()?.is_committed());
+    assert_eq!(ds.chunk(), Some(vec![2]));
+    let values: Vec<Point> = (0..4).map(|i| Point { x: f64::from(i), tag: i }).collect();
+    ds.write(&values)?;
+    assert_eq!(ds.read_1d::<Point>()?.to_vec(), values);
+    Ok(())
+}
+
+#[test]
+fn test_with_data_as_committed_datatype() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let dtype = hdf5::Datatype::from_type::<Point>()?;
+    file.commit_datatype("point", &dtype)?;
+    let committed = file.committed_datatype("point")?;
+
+    let values = [Point { x: 1.5, tag: 1 }, Point { x: -2.0, tag: 2 }];
+    let ds = file.new_dataset_builder().with_data_as(&values, &committed).create("ds")?;
+    assert!(ds.dtype()?.is_committed());
+    assert_eq!(ds.read_1d::<Point>()?.as_slice().unwrap(), &values);
+    Ok(())
+}
+
+#[test]
+fn test_with_data_as_datatype_checks_conversion() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let dtype = hdf5::Datatype::from_type::<i64>()?;
+    file.commit_datatype("wide", &dtype)?;
+
+    let soft = file.new_dataset_builder().with_data_as(&[1_i32, 2], &dtype).create("soft")?;
+    assert_eq!(soft.read_1d::<i64>()?.to_vec(), vec![1, 2]);
+    let strict =
+        file.new_dataset_builder().with_data_as(&[1_i32, 2], &dtype).no_convert().create("strict");
+    assert!(matches!(strict, Err(hdf5::Error::Internal(_))));
+    assert!(file.dataset("strict").is_err());
+    Ok(())
+}
+
+#[test]
+fn test_empty_as_datatype_converts_on_write() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let dtype = hdf5::Datatype::from_type::<i64>()?;
+    file.commit_datatype("wide", &dtype)?;
+
+    let ds = file.new_dataset_builder().empty_as(&dtype).shape(3).create("ds")?;
+    ds.write(&[1_i32, -2, 3])?;
+    assert_eq!(ds.read_1d::<i64>()?.to_vec(), vec![1, -2, 3]);
+    Ok(())
+}
+
+#[test]
+fn test_empty_as_datatype_varlen_string() -> hdf5::Result<()> {
+    let file = new_in_memory_file()?;
+    let dtype = hdf5::Datatype::from_type::<VarLenUnicode>()?;
+    file.commit_datatype("text", &dtype)?;
+
+    let ds = file.new_dataset_builder().empty_as(&dtype).shape(2).create("ds")?;
+    let values: Vec<VarLenUnicode> = ["héllo", ""].iter().map(|s| s.parse().unwrap()).collect();
+    ds.write(&values)?;
+    assert!(ds.dtype()?.is_committed());
+    assert_eq!(ds.read_1d::<VarLenUnicode>()?.to_vec(), values);
+    Ok(())
 }
 
 #[test]

--- a/hdf5/tests/test_dataset.rs
+++ b/hdf5/tests/test_dataset.rs
@@ -681,7 +681,9 @@ fn test_empty_as_datatype_reuses_dataset_type() -> hdf5::Result<()> {
     Ok(())
 }
 
+// A committed datatype from another file is stored as a copy from 1.8.18 and 1.10.1 on.
 #[test]
+#[cfg(any(all(feature = "1.8.18", not(feature = "1.10.0")), feature = "1.10.1"))]
 fn test_empty_as_datatype_from_other_file_stores_copy() -> hdf5::Result<()> {
     let origin = new_in_memory_file()?;
     let dtype = hdf5::Datatype::from_type::<Point>()?;
@@ -692,6 +694,23 @@ fn test_empty_as_datatype_from_other_file_stores_copy() -> hdf5::Result<()> {
     assert!(!ds.dtype()?.is_committed());
     assert_eq!(ds.dtype()?.to_descriptor()?, dtype.to_descriptor()?);
     assert!(file.committed_datatypes()?.is_empty());
+    Ok(())
+}
+
+// Older libraries would write a reference into the other file, so the crate rejects it.
+#[test]
+#[cfg(not(any(all(feature = "1.8.18", not(feature = "1.10.0")), feature = "1.10.1")))]
+fn test_empty_as_datatype_from_other_file_is_rejected() -> hdf5::Result<()> {
+    let origin = new_in_memory_file()?;
+    let dtype = hdf5::Datatype::from_type::<Point>()?;
+    origin.commit_datatype("point", &dtype)?;
+
+    let file = new_in_memory_file()?;
+    let err = file.new_dataset_builder().empty_as(&dtype).create("copy");
+    assert!(matches!(err, Err(hdf5::Error::Internal(_))));
+    assert!(file.dataset("copy").is_err());
+    let same_file = origin.new_dataset_builder().empty_as(&dtype).create("ok")?;
+    assert!(same_file.dtype()?.is_committed());
     Ok(())
 }
 


### PR DESCRIPTION
Builds on top of https://github.com/metno/hdf5-rust/pull/219, https://github.com/metno/hdf5-rust/pull/220, & https://github.com/metno/hdf5-rust/pull/222

Resolves #221
Resolves #215 (the parent issue of the whole `comitted datatype` feature)