### PR TITLE
Declare HDF5_DIR and HDF5_VERSION as build script inputs on the bundled path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## hdf5-derive unreleased
 ## hdf5-types unreleased
 ## hdf5-sys unreleased
+- Rerun the build script when `HDF5_DIR` or `HDF5_VERSION` changes after a bundled build
 ## hdf5-src unreleased
 
 ## hdf5-sys 0.12.3

--- a/hdf5-sys/build.rs
+++ b/hdf5-sys/build.rs
@@ -690,9 +690,6 @@ impl Config {
         for dir in &self.link_paths {
             println!("cargo::rustc-link-search=native={}", dir.to_str().unwrap());
         }
-        println!("cargo::rerun-if-env-changed=HDF5_DIR");
-        println!("cargo::rerun-if-env-changed=HDF5_VERSION");
-
         if is_msvc() {
             println!("cargo::metadata=msvc_dll_indirection=1");
         }
@@ -769,6 +766,9 @@ impl Config {
 }
 
 fn main() {
+    println!("cargo::rerun-if-env-changed=HDF5_DIR");
+    println!("cargo::rerun-if-env-changed=HDF5_VERSION");
+
     if feature_enabled("STATIC") && std::env::var_os("HDF5_DIR").is_none() {
         get_build_and_emit();
     } else {


### PR DESCRIPTION
Resolves #227 

The rerun-if-env-changed lines were printed only from emit_link_flags, so a static build made with HDF5_DIR unset was not rerun when HDF5_DIR was set afterwards.